### PR TITLE
MMC1 fixes into Dev branch

### DIFF
--- a/nes-emu-ios/nes-emu-ios/Model/NES/PPU.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/PPU.swift
@@ -83,6 +83,7 @@ struct PPU
                   self.nmiOutput
             else { return }
             
+            // TODO: this fixes some games (e.g. Burger Time), but shouldn't be necessary - the timings are off somewhere
             self.nmiDelay = PPU.nmiMaximumDelay
         }
     }


### PR DESCRIPTION
- Fix PRG RAM banking offset (was using 4KB banking instead of 8KB)
- Fix out of bounds issues where a ROM could request a bank number that was higher than what's available on the cartridge

Holy Diver Batman 0.0.1 MMC1 ROMs are all booting with the above fixes, including a few ROMs that were booting to black screen before.

This doesn't fix some other issues reported for MMC1 (audio issues with a few games, and Qix Black screen issue)
