### PR TITLE
CPU and MMC1 fixes into Master

### DIFF
--- a/nes-emu-ios/nes-emu-ios/Model/NES/PPU.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/PPU.swift
@@ -83,6 +83,7 @@ struct PPU
                   self.nmiOutput
             else { return }
             
+            // TODO: this fixes some games (e.g. Burger Time), but shouldn't be necessary - the timings are off somewhere
             self.nmiDelay = PPU.nmiMaximumDelay
         }
     }


### PR DESCRIPTION
**CPU:**
- handle some 6502 addressing mode special cases.

**MMC1 Mapper:**
- Fix PRG RAM banking offset (was using 4KB banking instead of 8KB)
- Fix out of bounds issues where a ROM could request a bank number that was higher than what's available on the cartridge

This fixes some CPU Test ROMs, some MMC1 Holy Diver Batman 0.0.1 Test ROMS, as well as a bug with F-1 Race where extra road was drawn on the sides.  