### PR TITLE
CPU And Mapper Fixes (Dev to Master)

### DIFF
--- a/nes-emu-ios/nes-emu-ios.xcodeproj/project.pbxproj
+++ b/nes-emu-ios/nes-emu-ios.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		9929E3E9282F158D00ED43DA /* Mapper_TQROM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9929E3E7282F158D00ED43DA /* Mapper_TQROM.swift */; };
 		99301E7925302D4200CC2DBD /* Data+MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99301E7825302D4200CC2DBD /* Data+MD5.swift */; };
 		99301E7A25302D4200CC2DBD /* Data+MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99301E7825302D4200CC2DBD /* Data+MD5.swift */; };
+		9937C3492A3F84ED007A4CBA /* Mapper_ColorDreams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9937C3482A3F84ED007A4CBA /* Mapper_ColorDreams.swift */; };
+		9937C34A2A3F84ED007A4CBA /* Mapper_ColorDreams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9937C3482A3F84ED007A4CBA /* Mapper_ColorDreams.swift */; };
 		9943B32D2659A9B40085415D /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 9943B32C2659A9B40085415D /* Settings.bundle */; };
 		99488F40248985F100942A1E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99488F3F248985F100942A1E /* AppDelegate.swift */; };
 		99488F42248985F100942A1E /* DocumentBrowserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99488F41248985F100942A1E /* DocumentBrowserViewController.swift */; };
@@ -33,8 +35,8 @@
 		99488F4E248985F300942A1E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 99488F4C248985F300942A1E /* LaunchScreen.storyboard */; };
 		99488F592489BF8400942A1E /* UInt8+ByteUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99488F582489BF8400942A1E /* UInt8+ByteUtils.swift */; };
 		994C12122496F10600DD2FE1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994C12112496F10600DD2FE1 /* SceneDelegate.swift */; };
-		9953246224B5A86D000E9DE7 /* Mapper_ColorDreams_GxROM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9953246124B5A86D000E9DE7 /* Mapper_ColorDreams_GxROM.swift */; };
-		9953246324B5A86D000E9DE7 /* Mapper_ColorDreams_GxROM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9953246124B5A86D000E9DE7 /* Mapper_ColorDreams_GxROM.swift */; };
+		9953246224B5A86D000E9DE7 /* Mapper_GxROM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9953246124B5A86D000E9DE7 /* Mapper_GxROM.swift */; };
+		9953246324B5A86D000E9DE7 /* Mapper_GxROM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9953246124B5A86D000E9DE7 /* Mapper_GxROM.swift */; };
 		995C9ADD249BECCA00429ECC /* Mapper_MMC1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995C9ADC249BECCA00429ECC /* Mapper_MMC1.swift */; };
 		995C9ADF249BECE000429ECC /* Mapper_CNROM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995C9ADE249BECE000429ECC /* Mapper_CNROM.swift */; };
 		995C9AE3249BED0B00429ECC /* Mapper_MMC2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995C9AE2249BED0B00429ECC /* Mapper_MMC2.swift */; };
@@ -221,6 +223,7 @@
 		992164A2249D113D00EB4BAA /* Mapper_AxROM.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mapper_AxROM.swift; sourceTree = "<group>"; };
 		9929E3E7282F158D00ED43DA /* Mapper_TQROM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mapper_TQROM.swift; sourceTree = "<group>"; };
 		99301E7825302D4200CC2DBD /* Data+MD5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+MD5.swift"; sourceTree = "<group>"; };
+		9937C3482A3F84ED007A4CBA /* Mapper_ColorDreams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mapper_ColorDreams.swift; sourceTree = "<group>"; };
 		9943B32C2659A9B40085415D /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		99488F3C248985F100942A1E /* nes-emu-ios.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "nes-emu-ios.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		99488F3F248985F100942A1E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -232,7 +235,7 @@
 		99488F4F248985F300942A1E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		99488F582489BF8400942A1E /* UInt8+ByteUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UInt8+ByteUtils.swift"; sourceTree = "<group>"; };
 		994C12112496F10600DD2FE1 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		9953246124B5A86D000E9DE7 /* Mapper_ColorDreams_GxROM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mapper_ColorDreams_GxROM.swift; sourceTree = "<group>"; };
+		9953246124B5A86D000E9DE7 /* Mapper_GxROM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mapper_GxROM.swift; sourceTree = "<group>"; };
 		995C9ADC249BECCA00429ECC /* Mapper_MMC1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mapper_MMC1.swift; sourceTree = "<group>"; };
 		995C9ADE249BECE000429ECC /* Mapper_CNROM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mapper_CNROM.swift; sourceTree = "<group>"; };
 		995C9AE2249BED0B00429ECC /* Mapper_MMC2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mapper_MMC2.swift; sourceTree = "<group>"; };
@@ -469,7 +472,8 @@
 				991A515828280185006CAFF6 /* Mapper_NROM.swift */,
 				99D71A842832160B009EB6AC /* Mapper_CamericaQuattro.swift */,
 				991A515B28281A55006CAFF6 /* Mapper_UNROM.swift */,
-				9953246124B5A86D000E9DE7 /* Mapper_ColorDreams_GxROM.swift */,
+				9953246124B5A86D000E9DE7 /* Mapper_GxROM.swift */,
+				9937C3482A3F84ED007A4CBA /* Mapper_ColorDreams.swift */,
 				99BD700C24B81BB500D9A70D /* Mapper_Namcot118_TengenMimic1.swift */,
 				99EA746E24F0ACEB005D0EAA /* Mapper_NTDEC2722.swift */,
 				99A2924A26CA00A500A4D79B /* Mapper_VRC2c_VRC4b_VRC4d.swift */,
@@ -807,7 +811,7 @@
 				995D077F2532BDAD008AD907 /* MapperState.swift in Sources */,
 				99886AB3281F019D00C55611 /* Mapper_VRC7.swift in Sources */,
 				996F42DE2534112D001A31D2 /* TriangleState.swift in Sources */,
-				9953246224B5A86D000E9DE7 /* Mapper_ColorDreams_GxROM.swift in Sources */,
+				9953246224B5A86D000E9DE7 /* Mapper_GxROM.swift in Sources */,
 				991B28C8248B43A700A6A6DD /* APU.swift in Sources */,
 				995C9ADD249BECCA00429ECC /* Mapper_MMC1.swift in Sources */,
 				99E2E21624966AB0008AFCDB /* MapperIdentifier.swift in Sources */,
@@ -826,6 +830,7 @@
 				995D080F25338007008AD907 /* NSManagedObject+PPUState.swift in Sources */,
 				99BD700D24B81BB500D9A70D /* Mapper_Namcot118_TengenMimic1.swift in Sources */,
 				99FEEA60249DBB280072D225 /* NesRomNavigationController.swift in Sources */,
+				9937C3492A3F84ED007A4CBA /* Mapper_ColorDreams.swift in Sources */,
 				99B1EDB2249EB0A800BC66F3 /* SettingsIconTextInfoCell.swift in Sources */,
 				991A515928280185006CAFF6 /* Mapper_NROM.swift in Sources */,
 				996F42FC253429F5001A31D2 /* NSManagedObject+DMCState.swift in Sources */,
@@ -866,7 +871,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9953246324B5A86D000E9DE7 /* Mapper_ColorDreams_GxROM.swift in Sources */,
+				9953246324B5A86D000E9DE7 /* Mapper_GxROM.swift in Sources */,
 				995D081625338860008AD907 /* NSManagedObject+ConsoleState.swift in Sources */,
 				99FA3CAA24A6F1120065E539 /* Mapper_AxROM.swift in Sources */,
 				99FA3CB724A6F12A0065E539 /* PPU.swift in Sources */,
@@ -888,6 +893,7 @@
 				995D080A25337C74008AD907 /* NSManagedObject+MapperState.swift in Sources */,
 				99FA3CAB24A6F1140065E539 /* Mapper_CNROM.swift in Sources */,
 				99FA3CBD24A6F1500065E539 /* SampleRate.swift in Sources */,
+				9937C34A2A3F84ED007A4CBA /* Mapper_ColorDreams.swift in Sources */,
 				99A2924C26CA00A500A4D79B /* Mapper_VRC2c_VRC4b_VRC4d.swift in Sources */,
 				99B45545281E0A36006BFF3B /* Mapper_87.swift in Sources */,
 				99B45548281E39DC006BFF3B /* Mapper_78.swift in Sources */,

--- a/nes-emu-ios/nes-emu-ios/Extensions/UInt8+ByteUtils.swift
+++ b/nes-emu-ios/nes-emu-ios/Extensions/UInt8+ByteUtils.swift
@@ -38,25 +38,6 @@ extension UInt8
         return result
     }
     
-    /// Returns a UInt8 value from an array of 8 boolean values in big endian order (more significant, or "higher", bits first)
-    init(fromBigEndianBitArray aBigEndianBitArray: [Bool])
-    {
-        var retValue: UInt8 = 0
-        if aBigEndianBitArray.count == 8
-        {
-            retValue += aBigEndianBitArray[7] ? 1 : 0
-            retValue += aBigEndianBitArray[6] ? 2 : 0
-            retValue += aBigEndianBitArray[5] ? 4 : 0
-            retValue += aBigEndianBitArray[4] ? 8 : 0
-            retValue += aBigEndianBitArray[3] ? 16 : 0
-            retValue += aBigEndianBitArray[2] ? 32 : 0
-            retValue += aBigEndianBitArray[1] ? 64 : 0
-            retValue += aBigEndianBitArray[0] ? 128 : 0
-        }
-        
-        self.init(retValue)
-    }
-    
     /// Returns an array of 8 boolean values in little-endian order (less significant, or "lower", bits first)
     var littleEndianBitArray: [Bool]
     {

--- a/nes-emu-ios/nes-emu-ios/Model/NES/CPU.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/CPU.swift
@@ -96,260 +96,260 @@ struct CPU
     private static let instructionTable: [InstructionInfo] = [
         InstructionInfo(instruction: CPU.brk, mode: .implied,          cycles: 7, pageBoundaryCycles: 0, bytes: 2), // 00
         InstructionInfo(instruction: CPU.ora, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 01
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 02
-        InstructionInfo(instruction: CPU.slo, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // 03
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 1, pageBoundaryCycles: 0, bytes: 1), // 02
+        InstructionInfo(instruction: CPU.slo, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 2), // 03
         InstructionInfo(instruction: CPU.nop, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 04
         InstructionInfo(instruction: CPU.ora, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 05
         InstructionInfo(instruction: CPU.asl, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2), // 06
-        InstructionInfo(instruction: CPU.slo, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 0), // 07
+        InstructionInfo(instruction: CPU.slo, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2), // 07
         InstructionInfo(instruction: CPU.php, mode: .implied,          cycles: 3, pageBoundaryCycles: 0, bytes: 1), // 08
         InstructionInfo(instruction: CPU.ora, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // 09
         InstructionInfo(instruction: CPU.asl, mode: .accumulator,      cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 0A
-        InstructionInfo(instruction: CPU.anc, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 0B
+        InstructionInfo(instruction: CPU.anc, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // 0B
         InstructionInfo(instruction: CPU.nop, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 0C
         InstructionInfo(instruction: CPU.ora, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 0D
         InstructionInfo(instruction: CPU.asl, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // 0E
-        InstructionInfo(instruction: CPU.slo, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 0F
+        InstructionInfo(instruction: CPU.slo, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // 0F
         InstructionInfo(instruction: CPU.bpl, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2), // 10
         InstructionInfo(instruction: CPU.ora, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2), // 11
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 12
-        InstructionInfo(instruction: CPU.slo, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // 13
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 1, pageBoundaryCycles: 0, bytes: 1), // 12
+        InstructionInfo(instruction: CPU.slo, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 2), // 13
         InstructionInfo(instruction: CPU.nop, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 14
         InstructionInfo(instruction: CPU.ora, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 15
         InstructionInfo(instruction: CPU.asl, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 16
-        InstructionInfo(instruction: CPU.slo, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 17
+        InstructionInfo(instruction: CPU.slo, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 17
         InstructionInfo(instruction: CPU.clc, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 18
         InstructionInfo(instruction: CPU.ora, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 19
         InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 1A
-        InstructionInfo(instruction: CPU.slo, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // 1B
+        InstructionInfo(instruction: CPU.slo, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // 1B
         InstructionInfo(instruction: CPU.nop, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 1C
         InstructionInfo(instruction: CPU.ora, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 1D
         InstructionInfo(instruction: CPU.asl, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // 1E
-        InstructionInfo(instruction: CPU.slo, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // 1F
+        InstructionInfo(instruction: CPU.slo, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // 1F
         InstructionInfo(instruction: CPU.jsr, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // 20
         InstructionInfo(instruction: CPU.and, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 21
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 22
-        InstructionInfo(instruction: CPU.rla, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // 23
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 1, pageBoundaryCycles: 0, bytes: 1), // 22
+        InstructionInfo(instruction: CPU.rla, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 2), // 23
         InstructionInfo(instruction: CPU.bit, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 24
         InstructionInfo(instruction: CPU.and, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 25
         InstructionInfo(instruction: CPU.rol, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2), // 26
-        InstructionInfo(instruction: CPU.rla, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 0), // 27
+        InstructionInfo(instruction: CPU.rla, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2), // 27
         InstructionInfo(instruction: CPU.plp, mode: .implied,          cycles: 4, pageBoundaryCycles: 0, bytes: 1), // 28
         InstructionInfo(instruction: CPU.and, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // 29
         InstructionInfo(instruction: CPU.rol, mode: .accumulator,      cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 2A
-        InstructionInfo(instruction: CPU.anc, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 2B
+        InstructionInfo(instruction: CPU.anc, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // 2B
         InstructionInfo(instruction: CPU.bit, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 2C
         InstructionInfo(instruction: CPU.and, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 2D
         InstructionInfo(instruction: CPU.rol, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // 2E
-        InstructionInfo(instruction: CPU.rla, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 2F
+        InstructionInfo(instruction: CPU.rla, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // 2F
         InstructionInfo(instruction: CPU.bmi, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2), // 30
         InstructionInfo(instruction: CPU.and, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2), // 31
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 32
-        InstructionInfo(instruction: CPU.rla, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // 33
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 1, pageBoundaryCycles: 0, bytes: 1), // 32
+        InstructionInfo(instruction: CPU.rla, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 2), // 33
         InstructionInfo(instruction: CPU.nop, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 34
         InstructionInfo(instruction: CPU.and, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 35
         InstructionInfo(instruction: CPU.rol, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 36
-        InstructionInfo(instruction: CPU.rla, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 37
+        InstructionInfo(instruction: CPU.rla, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 37
         InstructionInfo(instruction: CPU.sec, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 38
         InstructionInfo(instruction: CPU.and, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 39
         InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 3A
-        InstructionInfo(instruction: CPU.rla, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // 3B
+        InstructionInfo(instruction: CPU.rla, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // 3B
         InstructionInfo(instruction: CPU.nop, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 3C
         InstructionInfo(instruction: CPU.and, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 3D
         InstructionInfo(instruction: CPU.rol, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // 3E
-        InstructionInfo(instruction: CPU.rla, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // 3F
+        InstructionInfo(instruction: CPU.rla, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // 3F
         InstructionInfo(instruction: CPU.rti, mode: .implied,          cycles: 6, pageBoundaryCycles: 0, bytes: 1), // 40
         InstructionInfo(instruction: CPU.eor, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 41
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 42
-        InstructionInfo(instruction: CPU.sre, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // 43
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 1, pageBoundaryCycles: 0, bytes: 1), // 42
+        InstructionInfo(instruction: CPU.sre, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 2), // 43
         InstructionInfo(instruction: CPU.nop, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 44
         InstructionInfo(instruction: CPU.eor, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 45
         InstructionInfo(instruction: CPU.lsr, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2), // 46
-        InstructionInfo(instruction: CPU.sre, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 0), // 47
+        InstructionInfo(instruction: CPU.sre, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2), // 47
         InstructionInfo(instruction: CPU.pha, mode: .implied,          cycles: 3, pageBoundaryCycles: 0, bytes: 1), // 48
         InstructionInfo(instruction: CPU.eor, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // 49
         InstructionInfo(instruction: CPU.lsr, mode: .accumulator,      cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 4A
-        InstructionInfo(instruction: CPU.alr, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 4B
+        InstructionInfo(instruction: CPU.alr, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // 4B
         InstructionInfo(instruction: CPU.jmp, mode: .absolute,         cycles: 3, pageBoundaryCycles: 0, bytes: 3), // 4C
         InstructionInfo(instruction: CPU.eor, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 4D
         InstructionInfo(instruction: CPU.lsr, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // 4E
-        InstructionInfo(instruction: CPU.sre, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 4F
+        InstructionInfo(instruction: CPU.sre, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // 4F
         InstructionInfo(instruction: CPU.bvc, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2), // 50
         InstructionInfo(instruction: CPU.eor, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2), // 51
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 52
-        InstructionInfo(instruction: CPU.sre, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // 53
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 1, pageBoundaryCycles: 0, bytes: 1), // 52
+        InstructionInfo(instruction: CPU.sre, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 2), // 53
         InstructionInfo(instruction: CPU.nop, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 54
         InstructionInfo(instruction: CPU.eor, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 55
         InstructionInfo(instruction: CPU.lsr, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 56
-        InstructionInfo(instruction: CPU.sre, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 57
+        InstructionInfo(instruction: CPU.sre, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 57
         InstructionInfo(instruction: CPU.cli, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 58
         InstructionInfo(instruction: CPU.eor, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 59
         InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 5A
-        InstructionInfo(instruction: CPU.sre, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // 5B
+        InstructionInfo(instruction: CPU.sre, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // 5B
         InstructionInfo(instruction: CPU.nop, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 5C
         InstructionInfo(instruction: CPU.eor, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 5D
         InstructionInfo(instruction: CPU.lsr, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // 5E
-        InstructionInfo(instruction: CPU.sre, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // 5F
+        InstructionInfo(instruction: CPU.sre, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // 5F
         InstructionInfo(instruction: CPU.rts, mode: .implied,          cycles: 6, pageBoundaryCycles: 0, bytes: 1), // 60
         InstructionInfo(instruction: CPU.adc, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 61
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 62
-        InstructionInfo(instruction: CPU.rra, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // 63
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 1, pageBoundaryCycles: 0, bytes: 1), // 62
+        InstructionInfo(instruction: CPU.rra, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 2), // 63
         InstructionInfo(instruction: CPU.nop, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 64
         InstructionInfo(instruction: CPU.adc, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 65
         InstructionInfo(instruction: CPU.ror, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2), // 66
-        InstructionInfo(instruction: CPU.rra, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 0), // 67
+        InstructionInfo(instruction: CPU.rra, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2), // 67
         InstructionInfo(instruction: CPU.pla, mode: .implied,          cycles: 4, pageBoundaryCycles: 0, bytes: 1), // 68
         InstructionInfo(instruction: CPU.adc, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // 69
         InstructionInfo(instruction: CPU.ror, mode: .accumulator,      cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 6A
-        InstructionInfo(instruction: CPU.arr, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 6B
+        InstructionInfo(instruction: CPU.arr, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // 6B
         InstructionInfo(instruction: CPU.jmp, mode: .indirect,         cycles: 5, pageBoundaryCycles: 0, bytes: 3), // 6C
         InstructionInfo(instruction: CPU.adc, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 6D
         InstructionInfo(instruction: CPU.ror, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // 6E
-        InstructionInfo(instruction: CPU.rra, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 6F
+        InstructionInfo(instruction: CPU.rra, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // 6F
         InstructionInfo(instruction: CPU.bvs, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2), // 70
         InstructionInfo(instruction: CPU.adc, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2), // 71
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 72
-        InstructionInfo(instruction: CPU.rra, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // 73
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 1, pageBoundaryCycles: 0, bytes: 1), // 72
+        InstructionInfo(instruction: CPU.rra, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 2), // 73
         InstructionInfo(instruction: CPU.nop, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 74
         InstructionInfo(instruction: CPU.adc, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 75
         InstructionInfo(instruction: CPU.ror, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 76
-        InstructionInfo(instruction: CPU.rra, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 77
+        InstructionInfo(instruction: CPU.rra, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 77
         InstructionInfo(instruction: CPU.sei, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 78
         InstructionInfo(instruction: CPU.adc, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 79
         InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 7A
-        InstructionInfo(instruction: CPU.rra, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // 7B
+        InstructionInfo(instruction: CPU.rra, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // 7B
         InstructionInfo(instruction: CPU.nop, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 7C
         InstructionInfo(instruction: CPU.adc, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 7D
         InstructionInfo(instruction: CPU.ror, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // 7E
-        InstructionInfo(instruction: CPU.rra, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // 7F
+        InstructionInfo(instruction: CPU.rra, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // 7F
         InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // 80
         InstructionInfo(instruction: CPU.sta, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 81
-        InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 82
-        InstructionInfo(instruction: CPU.sax, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 83
+        InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // 82
+        InstructionInfo(instruction: CPU.sax, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 83
         InstructionInfo(instruction: CPU.sty, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 84
         InstructionInfo(instruction: CPU.sta, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 85
         InstructionInfo(instruction: CPU.stx, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 86
-        InstructionInfo(instruction: CPU.sax, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 0), // 87
+        InstructionInfo(instruction: CPU.sax, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 87
         InstructionInfo(instruction: CPU.dey, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 88
-        InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 89
+        InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // 89
         InstructionInfo(instruction: CPU.txa, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 8A
-        InstructionInfo(instruction: CPU.xaa, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 8B
+        InstructionInfo(instruction: CPU.xaa, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // 8B
         InstructionInfo(instruction: CPU.sty, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 8C
         InstructionInfo(instruction: CPU.sta, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 8D
         InstructionInfo(instruction: CPU.stx, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 8E
-        InstructionInfo(instruction: CPU.sax, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 0), // 8F
+        InstructionInfo(instruction: CPU.sax, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 8F
         InstructionInfo(instruction: CPU.bcc, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2), // 90
         InstructionInfo(instruction: CPU.sta, mode: .indirectYIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 91
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 92
-        InstructionInfo(instruction: CPU.ahx, mode: .indirectYIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 93
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 1, pageBoundaryCycles: 0, bytes: 1), // 92
+        InstructionInfo(instruction: CPU.ahx, mode: .indirectYIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 93
         InstructionInfo(instruction: CPU.sty, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 94
         InstructionInfo(instruction: CPU.sta, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 95
         InstructionInfo(instruction: CPU.stx, mode: .zeroPageYIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 96
-        InstructionInfo(instruction: CPU.sax, mode: .zeroPageYIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 0), // 97
+        InstructionInfo(instruction: CPU.sax, mode: .zeroPageYIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 97
         InstructionInfo(instruction: CPU.tya, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 98
         InstructionInfo(instruction: CPU.sta, mode: .absoluteYIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 3), // 99
         InstructionInfo(instruction: CPU.txs, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 9A
-        InstructionInfo(instruction: CPU.tas, mode: .absoluteYIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 0), // 9B
-        InstructionInfo(instruction: CPU.shy, mode: .absoluteXIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 0), // 9C
+        InstructionInfo(instruction: CPU.tas, mode: .absoluteYIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 3), // 9B
+        InstructionInfo(instruction: CPU.shy, mode: .absoluteXIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 3), // 9C
         InstructionInfo(instruction: CPU.sta, mode: .absoluteXIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 3), // 9D
-        InstructionInfo(instruction: CPU.shx, mode: .absoluteYIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 0), // 9E
-        InstructionInfo(instruction: CPU.ahx, mode: .absoluteYIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 0), // 9F
+        InstructionInfo(instruction: CPU.shx, mode: .absoluteYIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 3), // 9E
+        InstructionInfo(instruction: CPU.ahx, mode: .absoluteYIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 3), // 9F
         InstructionInfo(instruction: CPU.ldy, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // A0
         InstructionInfo(instruction: CPU.lda, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // A1
         InstructionInfo(instruction: CPU.ldx, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // A2
-        InstructionInfo(instruction: CPU.lax, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 0), // A3
+        InstructionInfo(instruction: CPU.lax, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // A3
         InstructionInfo(instruction: CPU.ldy, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // A4
         InstructionInfo(instruction: CPU.lda, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // A5
         InstructionInfo(instruction: CPU.ldx, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // A6
-        InstructionInfo(instruction: CPU.lax, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 0), // A7
+        InstructionInfo(instruction: CPU.lax, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // A7
         InstructionInfo(instruction: CPU.tay, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // A8
         InstructionInfo(instruction: CPU.lda, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // A9
         InstructionInfo(instruction: CPU.tax, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // AA
-        InstructionInfo(instruction: CPU.lax, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // AB
+        InstructionInfo(instruction: CPU.lax, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // AB
         InstructionInfo(instruction: CPU.ldy, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // AC
         InstructionInfo(instruction: CPU.lda, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // AD
         InstructionInfo(instruction: CPU.ldx, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // AE
-        InstructionInfo(instruction: CPU.lax, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 0), // AF
+        InstructionInfo(instruction: CPU.lax, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // AF
         InstructionInfo(instruction: CPU.bcs, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2), // B0
         InstructionInfo(instruction: CPU.lda, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2), // B1
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // B2
-        InstructionInfo(instruction: CPU.lax, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 0), // B3
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 1, pageBoundaryCycles: 0, bytes: 1), // B2
+        InstructionInfo(instruction: CPU.lax, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2), // B3
         InstructionInfo(instruction: CPU.ldy, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // B4
         InstructionInfo(instruction: CPU.lda, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // B5
         InstructionInfo(instruction: CPU.ldx, mode: .zeroPageYIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // B6
-        InstructionInfo(instruction: CPU.lax, mode: .zeroPageYIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 0), // B7
+        InstructionInfo(instruction: CPU.lax, mode: .zeroPageYIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // B7
         InstructionInfo(instruction: CPU.clv, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // B8
         InstructionInfo(instruction: CPU.lda, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // B9
         InstructionInfo(instruction: CPU.tsx, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // BA
-        InstructionInfo(instruction: CPU.las, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 0), // BB
+        InstructionInfo(instruction: CPU.las, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // BB
         InstructionInfo(instruction: CPU.ldy, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // BC
         InstructionInfo(instruction: CPU.lda, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // BD
         InstructionInfo(instruction: CPU.ldx, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // BE
-        InstructionInfo(instruction: CPU.lax, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 0), // BF
+        InstructionInfo(instruction: CPU.lax, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // BF
         InstructionInfo(instruction: CPU.cpy, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // C0
         InstructionInfo(instruction: CPU.cmp, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // C1
-        InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // C2
-        InstructionInfo(instruction: CPU.dcp, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // C3
+        InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // C2
+        InstructionInfo(instruction: CPU.dcp, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 2), // C3
         InstructionInfo(instruction: CPU.cpy, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // C4
         InstructionInfo(instruction: CPU.cmp, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // C5
         InstructionInfo(instruction: CPU.dec, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2), // C6
-        InstructionInfo(instruction: CPU.dcp, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 0), // C7
+        InstructionInfo(instruction: CPU.dcp, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2), // C7
         InstructionInfo(instruction: CPU.iny, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // C8
         InstructionInfo(instruction: CPU.cmp, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // C9
         InstructionInfo(instruction: CPU.dex, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // CA
-        InstructionInfo(instruction: CPU.axs, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // CB
+        InstructionInfo(instruction: CPU.axs, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // CB
         InstructionInfo(instruction: CPU.cpy, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // CC
         InstructionInfo(instruction: CPU.cmp, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // CD
         InstructionInfo(instruction: CPU.dec, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // CE
-        InstructionInfo(instruction: CPU.dcp, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 0), // CF
+        InstructionInfo(instruction: CPU.dcp, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // CF
         InstructionInfo(instruction: CPU.bne, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2), // D0
         InstructionInfo(instruction: CPU.cmp, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2), // D1
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // D2
-        InstructionInfo(instruction: CPU.dcp, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // D3
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 1, pageBoundaryCycles: 0, bytes: 1), // D2
+        InstructionInfo(instruction: CPU.dcp, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 2), // D3
         InstructionInfo(instruction: CPU.nop, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // D4
         InstructionInfo(instruction: CPU.cmp, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // D5
         InstructionInfo(instruction: CPU.dec, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // D6
-        InstructionInfo(instruction: CPU.dcp, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0), // D7
+        InstructionInfo(instruction: CPU.dcp, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // D7
         InstructionInfo(instruction: CPU.cld, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // D8
         InstructionInfo(instruction: CPU.cmp, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // D9
         InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // DA
-        InstructionInfo(instruction: CPU.dcp, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // DB
+        InstructionInfo(instruction: CPU.dcp, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // DB
         InstructionInfo(instruction: CPU.nop, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // DC
         InstructionInfo(instruction: CPU.cmp, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // DD
         InstructionInfo(instruction: CPU.dec, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // DE
-        InstructionInfo(instruction: CPU.dcp, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // DF
+        InstructionInfo(instruction: CPU.dcp, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // DF
         InstructionInfo(instruction: CPU.cpx, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // E0
         InstructionInfo(instruction: CPU.sbc, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // E1
-        InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // E2
-        InstructionInfo(instruction: CPU.isc, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // E3
+        InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // E2
+        InstructionInfo(instruction: CPU.isc, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 2), // E3
         InstructionInfo(instruction: CPU.cpx, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // E4
         InstructionInfo(instruction: CPU.sbc, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // E5
         InstructionInfo(instruction: CPU.inc, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2), // E6
-        InstructionInfo(instruction: CPU.isc, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 0), // E7
+        InstructionInfo(instruction: CPU.isc, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2), // E7
         InstructionInfo(instruction: CPU.inx, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // E8
         InstructionInfo(instruction: CPU.sbc, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // E9
         InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // EA
-        InstructionInfo(instruction: CPU.sbc, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // EB
+        InstructionInfo(instruction: CPU.sbc, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // EB
         InstructionInfo(instruction: CPU.cpx, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // EC
         InstructionInfo(instruction: CPU.sbc, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // ED
         InstructionInfo(instruction: CPU.inc, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // EE
-        InstructionInfo(instruction: CPU.isc, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 0), // EF
+        InstructionInfo(instruction: CPU.isc, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // EF
         InstructionInfo(instruction: CPU.beq, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2), // F0
         InstructionInfo(instruction: CPU.sbc, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2), // F1
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // F2
-        InstructionInfo(instruction: CPU.isc, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // F3
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 1, pageBoundaryCycles: 0, bytes: 1), // F2
+        InstructionInfo(instruction: CPU.isc, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 2), // F3
         InstructionInfo(instruction: CPU.nop, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // F4
         InstructionInfo(instruction: CPU.sbc, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // F5
         InstructionInfo(instruction: CPU.inc, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // F6
-        InstructionInfo(instruction: CPU.isc, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0), // F7
+        InstructionInfo(instruction: CPU.isc, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // F7
         InstructionInfo(instruction: CPU.sed, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // F8
         InstructionInfo(instruction: CPU.sbc, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // F9
         InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // FA
-        InstructionInfo(instruction: CPU.isc, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // FB
+        InstructionInfo(instruction: CPU.isc, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // FB
         InstructionInfo(instruction: CPU.nop, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // FC
         InstructionInfo(instruction: CPU.sbc, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // FD
         InstructionInfo(instruction: CPU.inc, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // FE
-        InstructionInfo(instruction: CPU.isc, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // FF
+        InstructionInfo(instruction: CPU.isc, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // FF
     ]
 
     /// number of cycles
@@ -1255,25 +1255,100 @@ struct CPU
     
     // MARK: Illegal Instructions
 
-    private static func ahx(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
-    private static func alr(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
-    private static func anc(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
-    private static func arr(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
-    private static func axs(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
-    private static func dcp(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
-    private static func isc(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
-    private static func kil(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
-    private static func las(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
-    private static func lax(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
-    private static func rla(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
-    private static func rra(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
-    private static func sax(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
-    private static func shx(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
-    private static func shy(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
-    private static func slo(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
-    private static func sre(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
-    private static func tas(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
-    private static func xaa(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo) {}
+    private static func ahx(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
+    
+    private static func alr(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
+    
+    private static func anc(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
+    
+    private static func arr(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
+    
+    private static func axs(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
+    
+    private static func dcp(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
+    
+    private static func isc(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
+    
+    private static func kil(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
+    
+    private static func las(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
+    
+    private static func lax(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
+    
+    private static func rla(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
+    
+    private static func rra(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
+    
+    private static func sax(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
+    
+    private static func shx(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
+    
+    private static func shy(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
+    
+    private static func slo(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
+    
+    private static func sre(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
+    
+    private static func tas(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
+    
+    private static func xaa(cpu aCPU: inout CPU, stepInfo aStepInfo: StepInfo)
+    {
+        
+    }
 }
 
 enum AddressingMode: UInt8

--- a/nes-emu-ios/nes-emu-ios/Model/NES/CPU.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/CPU.swift
@@ -94,262 +94,262 @@ struct CPU
     
     /// all 6502 op codes, containing all combinations of instructions and their associated addressing mode(s).  some op codes point to "illegal" instructions (such as slo, kil, anc, rla, sre, alr, rra, arr, sax, xaa, ahx, tas, shy, shx, lax, las, dcp, axs, isc) which won't do anything
     private static let instructionTable: [InstructionInfo] = [
-        InstructionInfo(instruction: CPU.brk, mode: .implied,          cycles: 7, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.ora, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.slo, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.nop, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.ora, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.asl, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.slo, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.php, mode: .implied,          cycles: 3, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.ora, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.asl, mode: .accumulator,      cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.anc, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.nop, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.ora, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.asl, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.slo, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.bpl, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2),
-        InstructionInfo(instruction: CPU.ora, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2),
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.slo, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.nop, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.ora, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.asl, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.slo, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.clc, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.ora, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.slo, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.nop, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.ora, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.asl, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.slo, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.jsr, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.and, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.rla, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.bit, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.and, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.rol, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.rla, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.plp, mode: .implied,          cycles: 4, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.and, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.rol, mode: .accumulator,      cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.anc, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.bit, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.and, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.rol, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.rla, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.bmi, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2),
-        InstructionInfo(instruction: CPU.and, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2),
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.rla, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.nop, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.and, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.rol, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.rla, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.sec, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.and, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.rla, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.nop, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.and, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.rol, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.rla, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.rti, mode: .implied,          cycles: 6, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.eor, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.sre, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.nop, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.eor, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.lsr, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.sre, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.pha, mode: .implied,          cycles: 3, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.eor, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.lsr, mode: .accumulator,      cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.alr, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.jmp, mode: .absolute,         cycles: 3, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.eor, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.lsr, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.sre, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.bvc, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2),
-        InstructionInfo(instruction: CPU.eor, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2),
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.sre, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.nop, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.eor, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.lsr, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.sre, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.cli, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.eor, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.sre, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.nop, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.eor, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.lsr, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.sre, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.rts, mode: .implied,          cycles: 6, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.adc, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.rra, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.nop, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.adc, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.ror, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.rra, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.pla, mode: .implied,          cycles: 4, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.adc, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.ror, mode: .accumulator,      cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.arr, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.jmp, mode: .indirect,         cycles: 5, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.adc, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.ror, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.rra, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.bvs, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2),
-        InstructionInfo(instruction: CPU.adc, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2),
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.rra, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.nop, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.adc, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.ror, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.rra, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.sei, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.adc, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.rra, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.nop, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.adc, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.ror, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.rra, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.sta, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.sax, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.sty, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.sta, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.stx, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.sax, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.dey, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.txa, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.xaa, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.sty, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.sta, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.stx, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.sax, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.bcc, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2),
-        InstructionInfo(instruction: CPU.sta, mode: .indirectYIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.ahx, mode: .indirectYIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.sty, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.sta, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.stx, mode: .zeroPageYIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.sax, mode: .zeroPageYIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.tya, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.sta, mode: .absoluteYIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.txs, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.tas, mode: .absoluteYIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.shy, mode: .absoluteXIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.sta, mode: .absoluteXIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.shx, mode: .absoluteYIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.ahx, mode: .absoluteYIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.ldy, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.lda, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.ldx, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.lax, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.ldy, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.lda, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.ldx, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.lax, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.tay, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.lda, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.tax, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.lax, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.ldy, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.lda, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.ldx, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.lax, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.bcs, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2),
-        InstructionInfo(instruction: CPU.lda, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2),
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.lax, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 0),
-        InstructionInfo(instruction: CPU.ldy, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.lda, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.ldx, mode: .zeroPageYIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.lax, mode: .zeroPageYIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.clv, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.lda, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.tsx, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.las, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 0),
-        InstructionInfo(instruction: CPU.ldy, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.lda, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.ldx, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.lax, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 0),
-        InstructionInfo(instruction: CPU.cpy, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.cmp, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.dcp, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.cpy, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.cmp, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.dec, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.dcp, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.iny, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.cmp, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.dex, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.axs, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.cpy, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.cmp, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.dec, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.dcp, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.bne, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2),
-        InstructionInfo(instruction: CPU.cmp, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2),
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.dcp, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.nop, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.cmp, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.dec, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.dcp, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.cld, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.cmp, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.dcp, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.nop, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.cmp, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.dec, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.dcp, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.cpx, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.sbc, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.isc, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.cpx, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.sbc, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.inc, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.isc, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.inx, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.sbc, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.sbc, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.cpx, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.sbc, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.inc, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.isc, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.beq, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2),
-        InstructionInfo(instruction: CPU.sbc, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2),
-        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.isc, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.nop, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.sbc, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.inc, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2),
-        InstructionInfo(instruction: CPU.isc, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.sed, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.sbc, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1),
-        InstructionInfo(instruction: CPU.isc, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0),
-        InstructionInfo(instruction: CPU.nop, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.sbc, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3),
-        InstructionInfo(instruction: CPU.inc, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3),
-        InstructionInfo(instruction: CPU.isc, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0),
+        InstructionInfo(instruction: CPU.brk, mode: .implied,          cycles: 7, pageBoundaryCycles: 0, bytes: 2), // 00
+        InstructionInfo(instruction: CPU.ora, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 01
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 02
+        InstructionInfo(instruction: CPU.slo, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // 03
+        InstructionInfo(instruction: CPU.nop, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 04
+        InstructionInfo(instruction: CPU.ora, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 05
+        InstructionInfo(instruction: CPU.asl, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2), // 06
+        InstructionInfo(instruction: CPU.slo, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 0), // 07
+        InstructionInfo(instruction: CPU.php, mode: .implied,          cycles: 3, pageBoundaryCycles: 0, bytes: 1), // 08
+        InstructionInfo(instruction: CPU.ora, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // 09
+        InstructionInfo(instruction: CPU.asl, mode: .accumulator,      cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 0A
+        InstructionInfo(instruction: CPU.anc, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 0B
+        InstructionInfo(instruction: CPU.nop, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 0C
+        InstructionInfo(instruction: CPU.ora, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 0D
+        InstructionInfo(instruction: CPU.asl, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // 0E
+        InstructionInfo(instruction: CPU.slo, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 0F
+        InstructionInfo(instruction: CPU.bpl, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2), // 10
+        InstructionInfo(instruction: CPU.ora, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2), // 11
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 12
+        InstructionInfo(instruction: CPU.slo, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // 13
+        InstructionInfo(instruction: CPU.nop, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 14
+        InstructionInfo(instruction: CPU.ora, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 15
+        InstructionInfo(instruction: CPU.asl, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 16
+        InstructionInfo(instruction: CPU.slo, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 17
+        InstructionInfo(instruction: CPU.clc, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 18
+        InstructionInfo(instruction: CPU.ora, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 19
+        InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 1A
+        InstructionInfo(instruction: CPU.slo, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // 1B
+        InstructionInfo(instruction: CPU.nop, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 1C
+        InstructionInfo(instruction: CPU.ora, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 1D
+        InstructionInfo(instruction: CPU.asl, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // 1E
+        InstructionInfo(instruction: CPU.slo, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // 1F
+        InstructionInfo(instruction: CPU.jsr, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // 20
+        InstructionInfo(instruction: CPU.and, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 21
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 22
+        InstructionInfo(instruction: CPU.rla, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // 23
+        InstructionInfo(instruction: CPU.bit, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 24
+        InstructionInfo(instruction: CPU.and, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 25
+        InstructionInfo(instruction: CPU.rol, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2), // 26
+        InstructionInfo(instruction: CPU.rla, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 0), // 27
+        InstructionInfo(instruction: CPU.plp, mode: .implied,          cycles: 4, pageBoundaryCycles: 0, bytes: 1), // 28
+        InstructionInfo(instruction: CPU.and, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // 29
+        InstructionInfo(instruction: CPU.rol, mode: .accumulator,      cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 2A
+        InstructionInfo(instruction: CPU.anc, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 2B
+        InstructionInfo(instruction: CPU.bit, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 2C
+        InstructionInfo(instruction: CPU.and, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 2D
+        InstructionInfo(instruction: CPU.rol, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // 2E
+        InstructionInfo(instruction: CPU.rla, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 2F
+        InstructionInfo(instruction: CPU.bmi, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2), // 30
+        InstructionInfo(instruction: CPU.and, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2), // 31
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 32
+        InstructionInfo(instruction: CPU.rla, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // 33
+        InstructionInfo(instruction: CPU.nop, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 34
+        InstructionInfo(instruction: CPU.and, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 35
+        InstructionInfo(instruction: CPU.rol, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 36
+        InstructionInfo(instruction: CPU.rla, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 37
+        InstructionInfo(instruction: CPU.sec, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 38
+        InstructionInfo(instruction: CPU.and, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 39
+        InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 3A
+        InstructionInfo(instruction: CPU.rla, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // 3B
+        InstructionInfo(instruction: CPU.nop, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 3C
+        InstructionInfo(instruction: CPU.and, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 3D
+        InstructionInfo(instruction: CPU.rol, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // 3E
+        InstructionInfo(instruction: CPU.rla, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // 3F
+        InstructionInfo(instruction: CPU.rti, mode: .implied,          cycles: 6, pageBoundaryCycles: 0, bytes: 1), // 40
+        InstructionInfo(instruction: CPU.eor, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 41
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 42
+        InstructionInfo(instruction: CPU.sre, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // 43
+        InstructionInfo(instruction: CPU.nop, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 44
+        InstructionInfo(instruction: CPU.eor, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 45
+        InstructionInfo(instruction: CPU.lsr, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2), // 46
+        InstructionInfo(instruction: CPU.sre, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 0), // 47
+        InstructionInfo(instruction: CPU.pha, mode: .implied,          cycles: 3, pageBoundaryCycles: 0, bytes: 1), // 48
+        InstructionInfo(instruction: CPU.eor, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // 49
+        InstructionInfo(instruction: CPU.lsr, mode: .accumulator,      cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 4A
+        InstructionInfo(instruction: CPU.alr, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 4B
+        InstructionInfo(instruction: CPU.jmp, mode: .absolute,         cycles: 3, pageBoundaryCycles: 0, bytes: 3), // 4C
+        InstructionInfo(instruction: CPU.eor, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 4D
+        InstructionInfo(instruction: CPU.lsr, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // 4E
+        InstructionInfo(instruction: CPU.sre, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 4F
+        InstructionInfo(instruction: CPU.bvc, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2), // 50
+        InstructionInfo(instruction: CPU.eor, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2), // 51
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 52
+        InstructionInfo(instruction: CPU.sre, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // 53
+        InstructionInfo(instruction: CPU.nop, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 54
+        InstructionInfo(instruction: CPU.eor, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 55
+        InstructionInfo(instruction: CPU.lsr, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 56
+        InstructionInfo(instruction: CPU.sre, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 57
+        InstructionInfo(instruction: CPU.cli, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 58
+        InstructionInfo(instruction: CPU.eor, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 59
+        InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 5A
+        InstructionInfo(instruction: CPU.sre, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // 5B
+        InstructionInfo(instruction: CPU.nop, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 5C
+        InstructionInfo(instruction: CPU.eor, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 5D
+        InstructionInfo(instruction: CPU.lsr, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // 5E
+        InstructionInfo(instruction: CPU.sre, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // 5F
+        InstructionInfo(instruction: CPU.rts, mode: .implied,          cycles: 6, pageBoundaryCycles: 0, bytes: 1), // 60
+        InstructionInfo(instruction: CPU.adc, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 61
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 62
+        InstructionInfo(instruction: CPU.rra, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // 63
+        InstructionInfo(instruction: CPU.nop, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 64
+        InstructionInfo(instruction: CPU.adc, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 65
+        InstructionInfo(instruction: CPU.ror, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2), // 66
+        InstructionInfo(instruction: CPU.rra, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 0), // 67
+        InstructionInfo(instruction: CPU.pla, mode: .implied,          cycles: 4, pageBoundaryCycles: 0, bytes: 1), // 68
+        InstructionInfo(instruction: CPU.adc, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // 69
+        InstructionInfo(instruction: CPU.ror, mode: .accumulator,      cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 6A
+        InstructionInfo(instruction: CPU.arr, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 6B
+        InstructionInfo(instruction: CPU.jmp, mode: .indirect,         cycles: 5, pageBoundaryCycles: 0, bytes: 3), // 6C
+        InstructionInfo(instruction: CPU.adc, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 6D
+        InstructionInfo(instruction: CPU.ror, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // 6E
+        InstructionInfo(instruction: CPU.rra, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 6F
+        InstructionInfo(instruction: CPU.bvs, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2), // 70
+        InstructionInfo(instruction: CPU.adc, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2), // 71
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 72
+        InstructionInfo(instruction: CPU.rra, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // 73
+        InstructionInfo(instruction: CPU.nop, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 74
+        InstructionInfo(instruction: CPU.adc, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 75
+        InstructionInfo(instruction: CPU.ror, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 76
+        InstructionInfo(instruction: CPU.rra, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 77
+        InstructionInfo(instruction: CPU.sei, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 78
+        InstructionInfo(instruction: CPU.adc, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 79
+        InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 7A
+        InstructionInfo(instruction: CPU.rra, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // 7B
+        InstructionInfo(instruction: CPU.nop, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 7C
+        InstructionInfo(instruction: CPU.adc, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // 7D
+        InstructionInfo(instruction: CPU.ror, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // 7E
+        InstructionInfo(instruction: CPU.rra, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // 7F
+        InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // 80
+        InstructionInfo(instruction: CPU.sta, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 81
+        InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 82
+        InstructionInfo(instruction: CPU.sax, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 83
+        InstructionInfo(instruction: CPU.sty, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 84
+        InstructionInfo(instruction: CPU.sta, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 85
+        InstructionInfo(instruction: CPU.stx, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // 86
+        InstructionInfo(instruction: CPU.sax, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 0), // 87
+        InstructionInfo(instruction: CPU.dey, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 88
+        InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 89
+        InstructionInfo(instruction: CPU.txa, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 8A
+        InstructionInfo(instruction: CPU.xaa, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 8B
+        InstructionInfo(instruction: CPU.sty, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 8C
+        InstructionInfo(instruction: CPU.sta, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 8D
+        InstructionInfo(instruction: CPU.stx, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // 8E
+        InstructionInfo(instruction: CPU.sax, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 0), // 8F
+        InstructionInfo(instruction: CPU.bcc, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2), // 90
+        InstructionInfo(instruction: CPU.sta, mode: .indirectYIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // 91
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // 92
+        InstructionInfo(instruction: CPU.ahx, mode: .indirectYIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0), // 93
+        InstructionInfo(instruction: CPU.sty, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 94
+        InstructionInfo(instruction: CPU.sta, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 95
+        InstructionInfo(instruction: CPU.stx, mode: .zeroPageYIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // 96
+        InstructionInfo(instruction: CPU.sax, mode: .zeroPageYIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 0), // 97
+        InstructionInfo(instruction: CPU.tya, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 98
+        InstructionInfo(instruction: CPU.sta, mode: .absoluteYIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 3), // 99
+        InstructionInfo(instruction: CPU.txs, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // 9A
+        InstructionInfo(instruction: CPU.tas, mode: .absoluteYIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 0), // 9B
+        InstructionInfo(instruction: CPU.shy, mode: .absoluteXIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 0), // 9C
+        InstructionInfo(instruction: CPU.sta, mode: .absoluteXIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 3), // 9D
+        InstructionInfo(instruction: CPU.shx, mode: .absoluteYIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 0), // 9E
+        InstructionInfo(instruction: CPU.ahx, mode: .absoluteYIndexed, cycles: 5, pageBoundaryCycles: 0, bytes: 0), // 9F
+        InstructionInfo(instruction: CPU.ldy, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // A0
+        InstructionInfo(instruction: CPU.lda, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // A1
+        InstructionInfo(instruction: CPU.ldx, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // A2
+        InstructionInfo(instruction: CPU.lax, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 0), // A3
+        InstructionInfo(instruction: CPU.ldy, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // A4
+        InstructionInfo(instruction: CPU.lda, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // A5
+        InstructionInfo(instruction: CPU.ldx, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // A6
+        InstructionInfo(instruction: CPU.lax, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 0), // A7
+        InstructionInfo(instruction: CPU.tay, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // A8
+        InstructionInfo(instruction: CPU.lda, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // A9
+        InstructionInfo(instruction: CPU.tax, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // AA
+        InstructionInfo(instruction: CPU.lax, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // AB
+        InstructionInfo(instruction: CPU.ldy, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // AC
+        InstructionInfo(instruction: CPU.lda, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // AD
+        InstructionInfo(instruction: CPU.ldx, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // AE
+        InstructionInfo(instruction: CPU.lax, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 0), // AF
+        InstructionInfo(instruction: CPU.bcs, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2), // B0
+        InstructionInfo(instruction: CPU.lda, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2), // B1
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // B2
+        InstructionInfo(instruction: CPU.lax, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 0), // B3
+        InstructionInfo(instruction: CPU.ldy, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // B4
+        InstructionInfo(instruction: CPU.lda, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // B5
+        InstructionInfo(instruction: CPU.ldx, mode: .zeroPageYIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // B6
+        InstructionInfo(instruction: CPU.lax, mode: .zeroPageYIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 0), // B7
+        InstructionInfo(instruction: CPU.clv, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // B8
+        InstructionInfo(instruction: CPU.lda, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // B9
+        InstructionInfo(instruction: CPU.tsx, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // BA
+        InstructionInfo(instruction: CPU.las, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 0), // BB
+        InstructionInfo(instruction: CPU.ldy, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // BC
+        InstructionInfo(instruction: CPU.lda, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // BD
+        InstructionInfo(instruction: CPU.ldx, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // BE
+        InstructionInfo(instruction: CPU.lax, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 0), // BF
+        InstructionInfo(instruction: CPU.cpy, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // C0
+        InstructionInfo(instruction: CPU.cmp, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // C1
+        InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // C2
+        InstructionInfo(instruction: CPU.dcp, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // C3
+        InstructionInfo(instruction: CPU.cpy, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // C4
+        InstructionInfo(instruction: CPU.cmp, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // C5
+        InstructionInfo(instruction: CPU.dec, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2), // C6
+        InstructionInfo(instruction: CPU.dcp, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 0), // C7
+        InstructionInfo(instruction: CPU.iny, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // C8
+        InstructionInfo(instruction: CPU.cmp, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // C9
+        InstructionInfo(instruction: CPU.dex, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // CA
+        InstructionInfo(instruction: CPU.axs, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // CB
+        InstructionInfo(instruction: CPU.cpy, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // CC
+        InstructionInfo(instruction: CPU.cmp, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // CD
+        InstructionInfo(instruction: CPU.dec, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // CE
+        InstructionInfo(instruction: CPU.dcp, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 0), // CF
+        InstructionInfo(instruction: CPU.bne, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2), // D0
+        InstructionInfo(instruction: CPU.cmp, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2), // D1
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // D2
+        InstructionInfo(instruction: CPU.dcp, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // D3
+        InstructionInfo(instruction: CPU.nop, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // D4
+        InstructionInfo(instruction: CPU.cmp, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // D5
+        InstructionInfo(instruction: CPU.dec, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // D6
+        InstructionInfo(instruction: CPU.dcp, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0), // D7
+        InstructionInfo(instruction: CPU.cld, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // D8
+        InstructionInfo(instruction: CPU.cmp, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // D9
+        InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // DA
+        InstructionInfo(instruction: CPU.dcp, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // DB
+        InstructionInfo(instruction: CPU.nop, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // DC
+        InstructionInfo(instruction: CPU.cmp, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // DD
+        InstructionInfo(instruction: CPU.dec, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // DE
+        InstructionInfo(instruction: CPU.dcp, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // DF
+        InstructionInfo(instruction: CPU.cpx, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // E0
+        InstructionInfo(instruction: CPU.sbc, mode: .xIndexedIndirect, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // E1
+        InstructionInfo(instruction: CPU.nop, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // E2
+        InstructionInfo(instruction: CPU.isc, mode: .xIndexedIndirect, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // E3
+        InstructionInfo(instruction: CPU.cpx, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // E4
+        InstructionInfo(instruction: CPU.sbc, mode: .zeropage,         cycles: 3, pageBoundaryCycles: 0, bytes: 2), // E5
+        InstructionInfo(instruction: CPU.inc, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 2), // E6
+        InstructionInfo(instruction: CPU.isc, mode: .zeropage,         cycles: 5, pageBoundaryCycles: 0, bytes: 0), // E7
+        InstructionInfo(instruction: CPU.inx, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // E8
+        InstructionInfo(instruction: CPU.sbc, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 2), // E9
+        InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // EA
+        InstructionInfo(instruction: CPU.sbc, mode: .immediate,        cycles: 2, pageBoundaryCycles: 0, bytes: 0), // EB
+        InstructionInfo(instruction: CPU.cpx, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // EC
+        InstructionInfo(instruction: CPU.sbc, mode: .absolute,         cycles: 4, pageBoundaryCycles: 0, bytes: 3), // ED
+        InstructionInfo(instruction: CPU.inc, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 3), // EE
+        InstructionInfo(instruction: CPU.isc, mode: .absolute,         cycles: 6, pageBoundaryCycles: 0, bytes: 0), // EF
+        InstructionInfo(instruction: CPU.beq, mode: .relative,         cycles: 2, pageBoundaryCycles: 1, bytes: 2), // F0
+        InstructionInfo(instruction: CPU.sbc, mode: .indirectYIndexed, cycles: 5, pageBoundaryCycles: 1, bytes: 2), // F1
+        InstructionInfo(instruction: CPU.kil, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 0), // F2
+        InstructionInfo(instruction: CPU.isc, mode: .indirectYIndexed, cycles: 8, pageBoundaryCycles: 0, bytes: 0), // F3
+        InstructionInfo(instruction: CPU.nop, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // F4
+        InstructionInfo(instruction: CPU.sbc, mode: .zeroPageXIndexed, cycles: 4, pageBoundaryCycles: 0, bytes: 2), // F5
+        InstructionInfo(instruction: CPU.inc, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 2), // F6
+        InstructionInfo(instruction: CPU.isc, mode: .zeroPageXIndexed, cycles: 6, pageBoundaryCycles: 0, bytes: 0), // F7
+        InstructionInfo(instruction: CPU.sed, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // F8
+        InstructionInfo(instruction: CPU.sbc, mode: .absoluteYIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // F9
+        InstructionInfo(instruction: CPU.nop, mode: .implied,          cycles: 2, pageBoundaryCycles: 0, bytes: 1), // FA
+        InstructionInfo(instruction: CPU.isc, mode: .absoluteYIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // FB
+        InstructionInfo(instruction: CPU.nop, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // FC
+        InstructionInfo(instruction: CPU.sbc, mode: .absoluteXIndexed, cycles: 4, pageBoundaryCycles: 1, bytes: 3), // FD
+        InstructionInfo(instruction: CPU.inc, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 3), // FE
+        InstructionInfo(instruction: CPU.isc, mode: .absoluteXIndexed, cycles: 7, pageBoundaryCycles: 0, bytes: 0), // FF
     ]
 
     /// number of cycles

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Cartridge.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Cartridge.swift
@@ -124,8 +124,8 @@ struct Cartridge: CartridgeProtocol
             return Mapper_MMC2(withCartridge: self, state: aState)
         case .MMC4:
             return Mapper_MMC4(withCartridge: self, state: aState)
-        case .ColorDreams, .GxROM:
-            return Mapper_ColorDreams_GxROM(withCartridge: self, state: aState)
+        case .ColorDreams:
+            return Mapper_ColorDreams(withCartridge: self, state: aState)
         case .MMC5:
             return Mapper_MMC5(withCartridge: self, state: aState)
         case .VRC2b_VRC4e_VRC4f:
@@ -134,6 +134,8 @@ struct Cartridge: CartridgeProtocol
             return Mapper_VRC2c_VRC4b_VRC4d(withCartridge: self, state: aState)
         case .VRC7:
             return Mapper_VRC7(withCartridge: self, state: aState)
+        case .GxROM:
+            return Mapper_GxROM(withCartridge: self, state: aState)
         case ._078:
             return Mapper_78(withCartridge: self, state: aState)
         case ._087:

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_78.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_78.swift
@@ -32,8 +32,8 @@ struct Mapper_78: MapperProtocol
     
     let hasExtendedNametableMapping: Bool = false
     
-    var mirroringMode: MirroringMode
-    let availableMirroringModes: [MirroringMode]
+    private(set) var mirroringMode: MirroringMode
+    private let availableMirroringModes: [MirroringMode]
     
     /// linear 1D array of all PRG blocks
     private let prg: [UInt8]

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_78.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_78.swift
@@ -36,10 +36,10 @@ struct Mapper_78: MapperProtocol
     let availableMirroringModes: [MirroringMode]
     
     /// linear 1D array of all PRG blocks
-    private var prg: [UInt8] = []
+    private let prg: [UInt8]
     
     /// linear 1D array of all CHR blocks
-    private var chr: [UInt8] = []
+    private let chr: [UInt8]
     
     /// 8KB CHR bank at $0000 ... $1FFF
     private var chrBank: Int
@@ -47,28 +47,39 @@ struct Mapper_78: MapperProtocol
     /// 16KB PRG bank at $8000 ... $BFFF
     private var prgBank: Int
     
-    private let fixedLastPrgBankIndex: Int
+    private let max16KBPrgBankOffset: Int
+    private let max16KBPrgBankIndexU8: UInt8
+    private let max8KBChrBankIndexU8: UInt8
     
     init(withCartridge aCartridge: CartridgeProtocol, state aState: MapperState? = nil)
     {
+        var c: [UInt8] = []
+        var p: [UInt8] = []
+        
+        for pBlock in aCartridge.prgBlocks
+        {
+            p.append(contentsOf: pBlock)
+        }
+        
+        for cBlock in aCartridge.chrBlocks
+        {
+            c.append(contentsOf: cBlock)
+        }
+        
+        self.prg = p
+        self.chr = c
+        
         if let safeState = aState
         {
             self.mirroringMode = MirroringMode.init(rawValue: safeState.mirroringMode) ?? aCartridge.header.mirroringMode
             self.chrBank = safeState.ints[safe: 0] ?? 0
             self.prgBank = safeState.ints[safe: 1] ?? 0
-            self.chr = safeState.chr
         }
         else
         {
             self.mirroringMode = aCartridge.header.mirroringMode
-
             self.chrBank = 0
             self.prgBank = 0
-            
-            for c in aCartridge.chrBlocks
-            {
-                self.chr.append(contentsOf: c)
-            }
         }
         
         switch aCartridge.header.mirroringMode {
@@ -78,32 +89,22 @@ struct Mapper_78: MapperProtocol
             self.availableMirroringModes = [MirroringMode.horizontal, MirroringMode.vertical]
         }
         
-        for p in aCartridge.prgBlocks
-        {
-            self.prg.append(contentsOf: p)
-        }
-        
-        self.fixedLastPrgBankIndex = max(0, (aCartridge.prgBlocks.count - 1) * 16384)
-        
-        if self.chr.count == 0
-        {
-            // use a block for CHR RAM if no block exists
-            self.chr.append(contentsOf: [UInt8].init(repeating: 0, count: 8192))
-        }
+        self.max16KBPrgBankOffset = max(0, (aCartridge.prgBlocks.count - 1) * 16384)
+        self.max16KBPrgBankIndexU8 = UInt8(max(0, aCartridge.chrBlocks.count - 1)) & 0x07
+        self.max8KBChrBankIndexU8 = UInt8(max(0, aCartridge.chrBlocks.count - 1)) & 0x0F
     }
     
     var mapperState: MapperState
     {
         get
         {
-            MapperState(mirroringMode: self.mirroringMode.rawValue, ints: [self.chrBank], bools: [], uint8s: [], chr: self.chr)
+            MapperState(mirroringMode: self.mirroringMode.rawValue, ints: [self.chrBank, self.prgBank], bools: [], uint8s: [], chr: [])
         }
         set
         {
             self.mirroringMode = MirroringMode.init(rawValue: newValue.mirroringMode) ?? self.mirroringMode
             self.chrBank = newValue.ints[safe: 0] ?? 0
             self.prgBank = newValue.ints[safe: 1] ?? 0
-            self.chr = newValue.chr
         }
     }
     
@@ -115,7 +116,7 @@ struct Mapper_78: MapperProtocol
         case 0x8000 ... 0xBFFF:
             return self.prg[(self.prgBank * 0x4000) + Int(aAddress - 0x8000)]
         case 0xC000 ... 0xFFFF: // last 16KB PRG bank
-            return self.prg[self.fixedLastPrgBankIndex + Int(aAddress - 0xC000)]
+            return self.prg[self.max16KBPrgBankOffset + Int(aAddress - 0xC000)]
         default:
             os_log("unhandled Mapper_87 read at address: 0x%04X", aAddress)
             return 0
@@ -136,8 +137,8 @@ struct Mapper_78: MapperProtocol
              |||| +----- Mirroring.  Holy Diver: 0 = H, 1 = V.  Cosmo Carrier: 0 = 1scA, 1 = 1scB.
              ++++------- Select 8KiB CHR ROM bank for PPU $0000-$1FFF
              */
-            self.prgBank = Int(aValue & 0x07)
-            self.chrBank = Int((aValue >> 4) & 0x0F)
+            self.prgBank = Int(aValue & self.max16KBPrgBankIndexU8)
+            self.chrBank = Int((aValue >> 4) & self.max8KBChrBankIndexU8)
             self.mirroringMode = self.availableMirroringModes[Int((aValue >> 3) & 1)]
         default:
             os_log("unhandled Mapper_87 write at address: 0x%04X", aAddress)
@@ -152,7 +153,7 @@ struct Mapper_78: MapperProtocol
     
     mutating func ppuWrite(address aAddress: UInt16, value aValue: UInt8) // 0x0000 ... 0x1FFF
     {
-        self.chr[(self.chrBank * 0x2000) + Int(aAddress)] = aValue
+        
     }
     
     func step(input aMapperStepInput: MapperStepInput) -> MapperStepResults?

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_87.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_87.swift
@@ -35,41 +35,44 @@ struct Mapper_87: MapperProtocol
     let mirroringMode: MirroringMode
     
     /// linear 1D array of all PRG blocks
-    private var prg: [UInt8] = []
+    private let prg: [UInt8]
     
     /// linear 1D array of all CHR blocks
-    private var chr: [UInt8] = []
+    private let chr: [UInt8]
     
     private var chrBank: Int
+    private let max8KBChrBankIndex: UInt8
     
     init(withCartridge aCartridge: CartridgeProtocol, state aState: MapperState? = nil)
     {
-        if let safeState = aState
+        var c: [UInt8] = []
+        var p: [UInt8] = []
+        
+        for pBlock in aCartridge.prgBlocks
+        {
+            p.append(contentsOf: pBlock)
+        }
+        
+        for cBlock in aCartridge.chrBlocks
+        {
+            c.append(contentsOf: cBlock)
+        }
+        
+        self.prg = p
+        self.chr = c
+        
+        self.max8KBChrBankIndex = UInt8(max(0, aCartridge.chrBlocks.count - 1)) & 0x03
+        
+        if let safeState = aState,
+           safeState.ints.count >= 1
         {
             self.mirroringMode = MirroringMode.init(rawValue: safeState.mirroringMode) ?? aCartridge.header.mirroringMode
-            self.chrBank = safeState.ints[safe: 0] ?? 0
-            self.chr = safeState.chr
+            self.chrBank = safeState.ints[0]
         }
         else
         {
             self.mirroringMode = aCartridge.header.mirroringMode
             self.chrBank = 0
-            
-            for c in aCartridge.chrBlocks
-            {
-                self.chr.append(contentsOf: c)
-            }
-        }
-        
-        for p in aCartridge.prgBlocks
-        {
-            self.prg.append(contentsOf: p)
-        }
-        
-        if self.chr.count == 0
-        {
-            // use a block for CHR RAM if no block exists
-            self.chr.append(contentsOf: [UInt8].init(repeating: 0, count: 8192))
         }
     }
     
@@ -77,12 +80,12 @@ struct Mapper_87: MapperProtocol
     {
         get
         {
-            MapperState(mirroringMode: self.mirroringMode.rawValue, ints: [self.chrBank], bools: [], uint8s: [], chr: self.chr)
+            MapperState(mirroringMode: self.mirroringMode.rawValue, ints: [self.chrBank], bools: [], uint8s: [], chr: [])
         }
         set
         {
-            self.chrBank = newValue.ints[safe: 0] ?? 0
-            self.chr = newValue.chr
+            guard newValue.ints.count >= 1 else { return }
+            self.chrBank = newValue.ints[0]
         }
     }
     
@@ -109,9 +112,7 @@ struct Mapper_87: MapperProtocol
           
             This reg selects 8k CHR @ $0000.  Note the reversed bit orders.  Most games using this mapper only have 16k CHR, so the 'H' bit is usually unused.
              */
-
-            self.chrBank = ((aValue >> 1) & 1 == 1 ? 1 : 0) + (aValue & 1 == 1 ? 2 : 0) // low bit 1 plus high bit 0
-            
+            self.chrBank = Int(((aValue << 1) & 0b00000010) | ((aValue >> 1) & 0b00000001) & self.max8KBChrBankIndex)
         default:
             os_log("unhandled Mapper_87 write at address: 0x%04X", aAddress)
             break
@@ -125,7 +126,7 @@ struct Mapper_87: MapperProtocol
     
     mutating func ppuWrite(address aAddress: UInt16, value aValue: UInt8) // 0x0000 ... 0x1FFF
     {
-        self.chr[(self.chrBank * 0x2000) + Int(aAddress)] = aValue
+        
     }
     
     func step(input aMapperStepInput: MapperStepInput) -> MapperStepResults?

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_AxROM.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_AxROM.swift
@@ -40,31 +40,25 @@ struct Mapper_AxROM: MapperProtocol
     private let prg: [UInt8]
     
     /// 8KB of CHR RAM addressable though 0x0000 ... 0x1FFF
-    private var chr: [UInt8] = [UInt8].init(repeating: 0, count: 8192)
-    
-    /// 8KB of SRAM addressable through 0x6000 ... 0x7FFF
-    private var sram: [UInt8] = [UInt8].init(repeating: 0, count: 8192)
+    private var chrRam: [UInt8]
     
     private let max32KBPrgBankIndex: UInt8
     
     init(withCartridge aCartridge: CartridgeProtocol, state aState: MapperState? = nil)
     {
-        if let safeState = aState
+        if let safeState = aState,
+           safeState.uint8s.count >= 8192,
+           safeState.ints.count >= 1
         {
             self.mirroringMode = MirroringMode.init(rawValue: safeState.mirroringMode) ?? aCartridge.header.mirroringMode
-            self.prgBank = safeState.ints[safe: 0] ?? 0
-            
-            self.chr = safeState.chr
+            self.prgBank = safeState.ints[0]
+            self.chrRam = [UInt8](safeState.uint8s[0 ..< 8192])
         }
         else
         {
             self.mirroringMode = aCartridge.header.mirroringMode
             self.prgBank = 0
-            
-            for c in aCartridge.chrBlocks
-            {
-                self.chr.append(contentsOf: c)
-            }
+            self.chrRam = [UInt8].init(repeating: 0, count: 8192)
         }
         
         var p: [UInt8] = []
@@ -72,23 +66,26 @@ struct Mapper_AxROM: MapperProtocol
         {
             p.append(contentsOf: pBlock)
         }
-        
         self.prg = p
-        self.max32KBPrgBankIndex = aCartridge.prgBlocks.count > 1 ? (UInt8((aCartridge.prgBlocks.count / 2) - 1) & 0x07) : 0
+        self.max32KBPrgBankIndex = aCartridge.prgBlocks.count > 1 ? (UInt8((aCartridge.prgBlocks.count / 2) - 1) & 0x0F) : 0
     }
     
     var mapperState: MapperState
     {
         get
         {
-            MapperState(mirroringMode: self.mirroringMode.rawValue, ints: [self.prgBank], bools: [], uint8s: [], chr: self.chr)
+            MapperState(mirroringMode: self.mirroringMode.rawValue, ints: [self.prgBank], bools: [], uint8s: self.chrRam, chr: [])
         }
         set
         {
+            guard newValue.uint8s.count >= 8192,
+                  newValue.ints.count >= 1
+            else {
+                return
+            }
             self.mirroringMode = MirroringMode.init(rawValue: newValue.mirroringMode) ?? self.mirroringMode
-            self.prgBank = newValue.ints[safe: 0] ?? 0
-            self.chr = newValue.chr
-        }
+            self.prgBank = newValue.ints[0]
+            self.chrRam = [UInt8](newValue.uint8s[0 ..< 8192])        }
     }
     
     func cpuRead(address aAddress: UInt16) -> UInt8 // 0x6000 ... 0xFFFF
@@ -98,7 +95,7 @@ struct Mapper_AxROM: MapperProtocol
         case 0x8000 ... 0xFFFF: // PRG Blocks
             return self.prg[self.prgBank * 0x8000 + Int(aAddress - 0x8000)]
         case 0x6000 ..< 0x8000:
-            return self.sram[Int(aAddress - 0x6000)]
+            return 0 // no SRAM
         default:
             os_log("unhandled Mapper_AxROM read at address: 0x%04X", aAddress)
             return 0
@@ -119,7 +116,7 @@ struct Mapper_AxROM: MapperProtocol
             default: break
             }
         case 0x6000 ..< 0x8000:
-            self.sram[Int(aAddress) - 0x6000] = aValue
+            break // no SRAM
         default:
             os_log("unhandled Mapper_AxROM write at address: 0x%04X", aAddress)
             break
@@ -128,12 +125,12 @@ struct Mapper_AxROM: MapperProtocol
     
     func ppuRead(address aAddress: UInt16) -> UInt8 // 0x0000 ... 0x1FFF
     {
-        return self.chr[Int(aAddress)]
+        return self.chrRam[Int(aAddress)]
     }
     
     mutating func ppuWrite(address aAddress: UInt16, value aValue: UInt8) // 0x0000 ... 0x1FFF
     {
-        self.chr[Int(aAddress)] = aValue
+        self.chrRam[Int(aAddress)] = aValue
     }
 
     func step(input aMapperStepInput: MapperStepInput) -> MapperStepResults?

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_AxROM.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_AxROM.swift
@@ -32,7 +32,7 @@ struct Mapper_AxROM: MapperProtocol
     
     let hasExtendedNametableMapping: Bool = false
     
-    var mirroringMode: MirroringMode
+    private(set) var mirroringMode: MirroringMode
     
     private var prgBank: Int
     

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_ColorDreams.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_ColorDreams.swift
@@ -68,7 +68,7 @@ struct Mapper_ColorDreams: MapperProtocol
         self.chr = chrRom
         
         let maxPrg32KBIndex: UInt8 = (UInt8(max(0, aCartridge.prgBlocks.count - 1)) / 2) & 0x03
-        self.max8KBChrBankIndex = UInt8(max(0, aCartridge.chrBlocks.count - 1)) & 0x03
+        self.max8KBChrBankIndex = UInt8(max(0, aCartridge.chrBlocks.count - 1)) & 0x0F
         self.max32KBPrgBankIndex = maxPrg32KBIndex
         
         self.mirroringMode = aCartridge.header.mirroringMode
@@ -107,7 +107,7 @@ struct Mapper_ColorDreams: MapperProtocol
         case 0x6000 ... 0x7FFF:
             return self.sram[Int(aAddress - 0x6000)]
         default:
-            os_log("unhandled Mapper_ColorDreams_GxROM read at address: 0x%04X", aAddress)
+            os_log("unhandled Mapper_ColorDreams read at address: 0x%04X", aAddress)
             return 0
         }
     }
@@ -131,7 +131,7 @@ struct Mapper_ColorDreams: MapperProtocol
         case 0x6000 ... 0x7FFF:
             return self.sram[Int(aAddress - 0x6000)] = aValue
         default:
-            os_log("unhandled Mapper_ColorDreams_GxROM CPU write at address: 0x%04X", aAddress)
+            os_log("unhandled Mapper_ColorDreams CPU write at address: 0x%04X", aAddress)
             break
         }
     }
@@ -143,7 +143,7 @@ struct Mapper_ColorDreams: MapperProtocol
     
     mutating func ppuWrite(address aAddress: UInt16, value aValue: UInt8)
     {
-        os_log("unhandled Mapper_ColorDreams_GxROM PPU write at address: 0x%04X", aAddress)
+        os_log("unhandled Mapper_ColorDreams PPU write at address: 0x%04X", aAddress)
     }
 
     mutating func step(input aMapperStepInput: MapperStepInput) -> MapperStepResults?

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_ColorDreams.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_ColorDreams.swift
@@ -1,5 +1,5 @@
 //
-//  Mapper_ColorDreams_GxROM.swift
+//  Mapper_ColorDreams.swift
 //  nes-emu-ios
 //
 //  Created by Tom Salvo on 7/8/20.
@@ -26,7 +26,7 @@
 import Foundation
 import os
 
-struct Mapper_ColorDreams_GxROM: MapperProtocol
+struct Mapper_ColorDreams: MapperProtocol
 {
     let hasStep: Bool = false
     
@@ -35,10 +35,10 @@ struct Mapper_ColorDreams_GxROM: MapperProtocol
     let mirroringMode: MirroringMode
     
     /// linear 1D array of all PRG blocks
-    private var prg: [UInt8] = []
+    private let prg: [UInt8]
     
     /// linear 1D array of all CHR blocks
-    private var chr: [UInt8] = []
+    private let chr: [UInt8]
     
     /// 8KB of SRAM addressible through 0x6000 ... 0x7FFF
     private var sram: [UInt8] = [UInt8].init(repeating: 0, count: 8192)
@@ -46,29 +46,42 @@ struct Mapper_ColorDreams_GxROM: MapperProtocol
     private var prgBank: Int = 0
     private var chrBank: Int = 0
     
+    private let max32KBPrgBankIndex: UInt8
+    private let max8KBChrBankIndex: UInt8
+    
     init(withCartridge aCartridge: CartridgeProtocol, state aState: MapperState? = nil)
     {
+        var chrRom: [UInt8] = []
+        var prgRom: [UInt8] = []
+        
         for p in aCartridge.prgBlocks
         {
-            self.prg.append(contentsOf: p)
+            prgRom.append(contentsOf: p)
         }
+        
+        for c in aCartridge.chrBlocks
+        {
+            chrRom.append(contentsOf: c)
+        }
+        
+        self.prg = prgRom
+        self.chr = chrRom
+        
+        let maxPrg32KBIndex: UInt8 = (UInt8(max(0, aCartridge.prgBlocks.count - 1)) / 2) & 0x03
+        self.max8KBChrBankIndex = UInt8(max(0, aCartridge.chrBlocks.count - 1)) & 0x03
+        self.max32KBPrgBankIndex = maxPrg32KBIndex
         
         self.mirroringMode = aCartridge.header.mirroringMode
         
         if let safeState = aState
         {
-            self.prgBank = safeState.ints[safe: 0] ?? 0
             self.chrBank = safeState.ints[safe: 1] ?? 0
-            self.chr = safeState.chr
+            self.prgBank = safeState.ints[safe: 0] ?? Int(maxPrg32KBIndex)
         }
         else
         {
             self.chrBank = 0
-            self.prgBank = max(0, self.prg.count - 0x8000) / 0x8000
-            for c in aCartridge.chrBlocks
-            {
-                self.chr.append(contentsOf: c)
-            }
+            self.prgBank = Int(maxPrg32KBIndex)
         }
     }
     
@@ -76,13 +89,12 @@ struct Mapper_ColorDreams_GxROM: MapperProtocol
     {
         get
         {
-            MapperState(mirroringMode: self.mirroringMode.rawValue, ints: [self.prgBank, self.chrBank], bools: [], uint8s: [], chr: self.chr)
+            MapperState(mirroringMode: self.mirroringMode.rawValue, ints: [self.prgBank, self.chrBank], bools: [], uint8s: [], chr: [])
         }
         set
         {
             self.prgBank = newValue.ints[safe: 0] ?? 0
             self.chrBank = newValue.ints[safe: 1] ?? 0
-            self.chr = newValue.chr
         }
     }
     
@@ -114,12 +126,12 @@ struct Mapper_ColorDreams_GxROM: MapperProtocol
              |||| ++--- Used for lockout defeat
              ++++------ Select 8 KB CHR ROM bank for PPU $0000-$1FFF
              */
-            self.chrBank = Int((aValue >> 4) & 0x0F)
-            self.prgBank = Int(aValue & 0x03)
+            self.chrBank = Int((aValue >> 4) & self.max8KBChrBankIndex)
+            self.prgBank = Int(aValue & self.max32KBPrgBankIndex)
         case 0x6000 ... 0x7FFF:
             return self.sram[Int(aAddress - 0x6000)] = aValue
         default:
-            os_log("unhandled Mapper_ColorDreams_GxROM write at address: 0x%04X", aAddress)
+            os_log("unhandled Mapper_ColorDreams_GxROM CPU write at address: 0x%04X", aAddress)
             break
         }
     }
@@ -131,7 +143,7 @@ struct Mapper_ColorDreams_GxROM: MapperProtocol
     
     mutating func ppuWrite(address aAddress: UInt16, value aValue: UInt8)
     {
-        self.chr[(self.chrBank * 0x2000) + Int(aAddress)] = aValue
+        os_log("unhandled Mapper_ColorDreams_GxROM PPU write at address: 0x%04X", aAddress)
     }
 
     mutating func step(input aMapperStepInput: MapperStepInput) -> MapperStepResults?

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_GxROM.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_GxROM.swift
@@ -1,0 +1,152 @@
+//
+//  Mapper_GxROM.swift
+//  nes-emu-ios
+//
+//  Created by Tom Salvo on 7/8/20.
+//  Copyright © 2020 Tom Salvo.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import Foundation
+import os
+
+struct Mapper_GxROM: MapperProtocol
+{
+    let hasStep: Bool = false
+    
+    let hasExtendedNametableMapping: Bool = false
+    
+    let mirroringMode: MirroringMode
+    
+    /// linear 1D array of all PRG blocks
+    private let prg: [UInt8]
+    
+    /// linear 1D array of all CHR blocks
+    private let chr: [UInt8]
+    
+    /// 8KB of SRAM addressible through 0x6000 ... 0x7FFF
+    private var sram: [UInt8] = [UInt8].init(repeating: 0, count: 8192)
+    
+    private var prgBank: Int
+    private var chrBank: Int
+    
+    private let max32KBPrgBankIndex: UInt8
+    private let max8KBChrBankIndex: UInt8
+    
+    init(withCartridge aCartridge: CartridgeProtocol, state aState: MapperState? = nil)
+    {
+        var chrRom: [UInt8] = []
+        var prgRom: [UInt8] = []
+        
+        for p in aCartridge.prgBlocks
+        {
+            prgRom.append(contentsOf: p)
+        }
+        
+        for c in aCartridge.chrBlocks
+        {
+            chrRom.append(contentsOf: c)
+        }
+        
+        self.prg = prgRom
+        self.chr = chrRom
+        
+        let maxPrg32KBIndex: UInt8 = (UInt8(max(0, aCartridge.prgBlocks.count - 1)) / 2) & 0x03
+        self.max8KBChrBankIndex = UInt8(max(0, aCartridge.chrBlocks.count - 1)) & 0x03
+        self.max32KBPrgBankIndex = maxPrg32KBIndex
+        
+        self.mirroringMode = aCartridge.header.mirroringMode
+        
+        if let safeState = aState
+        {
+            self.chrBank = safeState.ints[safe: 1] ?? 0
+            self.prgBank = safeState.ints[safe: 0] ?? Int(maxPrg32KBIndex)
+        }
+        else
+        {
+            self.chrBank = 0
+            self.prgBank = Int(maxPrg32KBIndex)
+        }
+    }
+    
+    var mapperState: MapperState
+    {
+        get
+        {
+            MapperState(mirroringMode: self.mirroringMode.rawValue, ints: [self.prgBank, self.chrBank], bools: [], uint8s: [], chr: [])
+        }
+        set
+        {
+            self.prgBank = newValue.ints[safe: 0] ?? 0
+            self.chrBank = newValue.ints[safe: 1] ?? 0
+        }
+    }
+    
+    func cpuRead(address aAddress: UInt16) -> UInt8 // 0x6000 ... 0xFFFF
+    {
+        switch aAddress
+        {
+        case 0x8000 ... 0xFFFF:
+            return self.prg[(self.prgBank * 0x8000) + Int(aAddress - 0x8000)]
+        case 0x6000 ... 0x7FFF:
+            return self.sram[Int(aAddress - 0x6000)]
+        default:
+            os_log("unhandled Mapper_ColorDreams_GxROM read at address: 0x%04X", aAddress)
+            return 0
+        }
+    }
+    
+    mutating func cpuWrite(address aAddress: UInt16, value aValue: UInt8) // 0x6000 ... 0xFFFF
+    {
+        switch aAddress
+        {
+        case 0x8000 ... 0xFFFF:
+            /*
+             7  bit  0
+             ---- ----
+             xxPP xxCC
+               ||   ||
+               ||   ++- Select 8 KB CHR ROM bank for PPU $0000-$1FFF
+               ++------ Select 32 KB PRG ROM bank for CPU $8000-$FFFF
+             */
+            self.prgBank = Int((aValue >> 4) & self.max32KBPrgBankIndex)
+            self.chrBank = Int(aValue & self.max8KBChrBankIndex)
+        case 0x6000 ... 0x7FFF:
+            return self.sram[Int(aAddress - 0x6000)] = aValue
+        default:
+            os_log("unhandled Mapper_ColorDreams_GxROM CPU write at address: 0x%04X", aAddress)
+            break
+        }
+    }
+    
+    mutating func ppuRead(address aAddress: UInt16) -> UInt8 // 0x0000 ... 0x1FFF
+    {
+        return self.chr[(self.chrBank * 0x2000) + Int(aAddress)]
+    }
+    
+    mutating func ppuWrite(address aAddress: UInt16, value aValue: UInt8)
+    {
+        os_log("unhandled Mapper_ColorDreams_GxROM PPU write at address: 0x%04X", aAddress)
+    }
+
+    mutating func step(input aMapperStepInput: MapperStepInput) -> MapperStepResults?
+    {
+        return nil
+    }
+}

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_GxROM.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_GxROM.swift
@@ -107,7 +107,7 @@ struct Mapper_GxROM: MapperProtocol
         case 0x6000 ... 0x7FFF:
             return self.sram[Int(aAddress - 0x6000)]
         default:
-            os_log("unhandled Mapper_ColorDreams_GxROM read at address: 0x%04X", aAddress)
+            os_log("unhandled Mapper_GxROM read at address: 0x%04X", aAddress)
             return 0
         }
     }
@@ -130,7 +130,7 @@ struct Mapper_GxROM: MapperProtocol
         case 0x6000 ... 0x7FFF:
             return self.sram[Int(aAddress - 0x6000)] = aValue
         default:
-            os_log("unhandled Mapper_ColorDreams_GxROM CPU write at address: 0x%04X", aAddress)
+            os_log("unhandled Mapper_GxROM CPU write at address: 0x%04X", aAddress)
             break
         }
     }
@@ -142,7 +142,7 @@ struct Mapper_GxROM: MapperProtocol
     
     mutating func ppuWrite(address aAddress: UInt16, value aValue: UInt8)
     {
-        os_log("unhandled Mapper_ColorDreams_GxROM PPU write at address: 0x%04X", aAddress)
+        os_log("unhandled Mapper_GxROM PPU write at address: 0x%04X", aAddress)
     }
 
     mutating func step(input aMapperStepInput: MapperStepInput) -> MapperStepResults?

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_MMC1.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_MMC1.swift
@@ -36,7 +36,7 @@ struct Mapper_MMC1: MapperProtocol
     // MARK: - Internal Variables
     let hasStep: Bool = true
     let hasExtendedNametableMapping: Bool = false
-    var mirroringMode: MirroringMode
+    private(set) var mirroringMode: MirroringMode
     
     // MARK: - Enum Type
     private enum Variant: UInt8 {

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_MMC2.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_MMC2.swift
@@ -32,7 +32,7 @@ struct Mapper_MMC2: MapperProtocol
     
     let hasExtendedNametableMapping: Bool = false
     
-    var mirroringMode: MirroringMode
+    private(set) var mirroringMode: MirroringMode
     
     /// linear 1D array of all PRG blocks
     private let prg: [UInt8]

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_MMC2.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_MMC2.swift
@@ -50,6 +50,9 @@ struct Mapper_MMC2: MapperProtocol
     private var prgBank1: Int // switch between different 8KB PRG Banks
     private let prgBank2: Int // fixed to last 3x 8KB PRG banks
     
+    private let max8KBPrgBankIndex: UInt8
+    private let max4KBChrBankIndex: UInt8
+    
     init(withCartridge aCartridge: CartridgeProtocol, state aState: MapperState? = nil)
     {
         var chrRom: [UInt8] = []
@@ -90,6 +93,8 @@ struct Mapper_MMC2: MapperProtocol
         }
         
         self.prgBank2 = max((aCartridge.prgBlocks.count * 16384) - (3 * 8192), 0)
+        self.max8KBPrgBankIndex = UInt8((aCartridge.prgBlocks.count * 2) - 1) & 0x0F
+        self.max4KBChrBankIndex = UInt8((aCartridge.chrBlocks.count * 2) - 1) & 0x1F
     }
     
     var mapperState: MapperState
@@ -131,15 +136,15 @@ struct Mapper_MMC2: MapperProtocol
         switch aAddress
         {
         case 0xA000 ..< 0xB000: // select 8KB PRG Bank 0-15 xxxxPPPP for CPU 0x8000-0x9FFF
-            self.prgBank1 = Int(aValue & 0x0F)
+            self.prgBank1 = Int(aValue & self.max8KBPrgBankIndex)
         case 0xB000 ..< 0xC000: // Select 4 KB CHR ROM bank 1 0-31 xxxCCCCC for PPU $0000-$0FFF
-            self.chrBanks1[0] = Int(aValue & 0x1F)
+            self.chrBanks1[0] = Int(aValue & self.max4KBChrBankIndex)
         case 0xC000 ..< 0xD000: // Select 4 KB CHR ROM bank 1 0-31 xxxCCCCC for PPU $0000-$0FFF
-            self.chrBanks1[1] = Int(aValue & 0x1F)
+            self.chrBanks1[1] = Int(aValue & self.max4KBChrBankIndex)
         case 0xD000 ..< 0xE000: // Select 4 KB CHR ROM bank 2 0-31 xxxCCCCC for PPU $1000-$1FFF when latch2 == 1
-            self.chrBanks2[0] = Int(aValue & 0x1F)
+            self.chrBanks2[0] = Int(aValue & self.max4KBChrBankIndex)
         case 0xE000 ..< 0xF000: // Select 4 KB CHR ROM bank 2 0-31 xxxCCCCC for PPU $1000-$1FFF
-            self.chrBanks2[1] = Int(aValue & 0x1F)
+            self.chrBanks2[1] = Int(aValue & self.max4KBChrBankIndex)
         case 0xF000 ... 0xFFFF:
             self.mirroringMode = (aValue & 0x01) == 0 ? .vertical : .horizontal
         default:

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_MMC3.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_MMC3.swift
@@ -40,6 +40,9 @@ struct Mapper_MMC3: MapperProtocol
     /// linear 1D array of all CHR blocks
     private let chr: [UInt8]
     
+    /// 8KB of CHR RAM used if there is no CHR ROM onboard (used only on TNROM variant boards - Famicom only)
+    private var chrRam: [UInt8] = [UInt8].init(repeating: 0, count: 8192)
+    
     /// 8KB of SRAM addressible through 0x6000 ... 0x7FFF
     private var sram: [UInt8] = [UInt8].init(repeating: 0, count: 8192)
     
@@ -52,6 +55,7 @@ struct Mapper_MMC3: MapperProtocol
     private var reload: UInt8
     private var counter: UInt8
     private var irqEnable: Bool
+    private let isChrRamEnabled: Bool
     
     init(withCartridge aCartridge: CartridgeProtocol, state aState: MapperState? = nil)
     {
@@ -69,7 +73,8 @@ struct Mapper_MMC3: MapperProtocol
             chrRom.append(contentsOf: c)
         }
         
-        self.chr = chrRom.isEmpty ? [UInt8].init(repeating: 0, count: 8192) : chrRom
+        self.chr = chrRom
+        self.isChrRamEnabled = chrRom.isEmpty
         
         if let safeState = aState,
            safeState.uint8s.count >= 8205,
@@ -181,14 +186,24 @@ struct Mapper_MMC3: MapperProtocol
     
     func ppuRead(address aAddress: UInt16) -> UInt8 // 0x0000 ... 0x1FFF
     {
-        let bank = aAddress / 0x0400
-        let offset = aAddress % 0x0400
-        return self.chr[self.chrOffsets[Int(bank)] + Int(offset)]
+        if self.isChrRamEnabled
+        {
+            return self.chrRam[Int(aAddress)]
+        }
+        else
+        {
+            let bank = aAddress / 0x0400
+            let offset = aAddress % 0x0400
+            return self.chr[self.chrOffsets[Int(bank)] + Int(offset)]
+        }
     }
     
     mutating func ppuWrite(address aAddress: UInt16, value aValue: UInt8) // 0x0000 ... 0x1FFF
     {
-
+        if self.isChrRamEnabled
+        {
+            self.chrRam[Int(aAddress)] = aValue
+        }
     }
     
     mutating func step(input aMapperStepInput: MapperStepInput) -> MapperStepResults?
@@ -215,73 +230,110 @@ struct Mapper_MMC3: MapperProtocol
 
     private mutating func writeRegister(address aAddress: UInt16, value aValue: UInt8)
     {
+        let isEven: Bool = aAddress & 0x0001 == 0
         switch aAddress
         {
         case 0x8000 ... 0x9FFF:
-            if aAddress % 2 == 0
+            switch isEven
             {
-                self.writeBankSelect(value: aValue)
-            }
-            else
-            {
-                self.writeBankData(value: aValue)
+            case true:
+                /*
+                 Bank select ($8000-$9FFE, even)
+                 7  bit  0
+                 ---- ----
+                 CPMx xRRR
+                 |||   |||
+                 |||   +++- Specify which bank register to update on next write to Bank Data register
+                 |||          000: R0: Select 2 KB CHR bank at PPU $0000-$07FF (or $1000-$17FF)
+                 |||          001: R1: Select 2 KB CHR bank at PPU $0800-$0FFF (or $1800-$1FFF)
+                 |||          010: R2: Select 1 KB CHR bank at PPU $1000-$13FF (or $0000-$03FF)
+                 |||          011: R3: Select 1 KB CHR bank at PPU $1400-$17FF (or $0400-$07FF)
+                 |||          100: R4: Select 1 KB CHR bank at PPU $1800-$1BFF (or $0800-$0BFF)
+                 |||          101: R5: Select 1 KB CHR bank at PPU $1C00-$1FFF (or $0C00-$0FFF)
+                 |||          110: R6: Select 8 KB PRG ROM bank at $8000-$9FFF (or $C000-$DFFF)
+                 |||          111: R7: Select 8 KB PRG ROM bank at $A000-$BFFF
+                 ||+------- Nothing on the MMC3, see MMC6
+                 |+-------- PRG ROM bank mode (0: $8000-$9FFF swappable,
+                 |                                $C000-$DFFF fixed to second-last bank;
+                 |                             1: $C000-$DFFF swappable,
+                 |                                $8000-$9FFF fixed to second-last bank)
+                 +--------- CHR A12 inversion (0: two 2 KB banks at $0000-$0FFF,
+                                                  four 1 KB banks at $1000-$1FFF;
+                                               1: two 2 KB banks at $1000-$1FFF,
+                                                  four 1 KB banks at $0000-$0FFF)
+                 */
+                self.prgMode = (aValue >> 6) & 0x01
+                self.chrMode = (aValue >> 7) & 0x01
+                self.register = aValue & 0x07
+                self.updateOffsets()
+            case false:
+                /*
+                 Bank data ($8001-$9FFF, odd)
+                 7  bit  0
+                 ---- ----
+                 DDDD DDDD
+                 |||| ||||
+                 ++++-++++- New bank value, based on last value written to Bank select register (mentioned above)
+                 */
+                self.registers[Int(self.register)] = aValue
+                self.updateOffsets()
             }
         case 0xA000 ... 0xBFFF:
-            if aAddress % 2 == 0
+            switch isEven
             {
-                self.writeMirror(value: aValue)
-            }
-            else
-            {
-                self.writeProtect()
+            case true:
+                /*
+                 Mirroring ($A000-$BFFE, even)
+                 7  bit  0
+                 ---- ----
+                 xxxx xxxM
+                         |
+                         +- Nametable mirroring (0: vertical; 1: horizontal)
+                 */
+                self.mirroringMode = aValue & 0x01 == 0 ? .vertical : .horizontal
+            case false:
+                /*
+                 PRG RAM protect ($A001-$BFFF, odd)
+                 7  bit  0
+                 ---- ----
+                 RWXX xxxx
+                 ||||
+                 ||++------ Nothing on the MMC3, see MMC6
+                 |+-------- Write protection (0: allow writes; 1: deny writes)
+                 +--------- PRG RAM chip enable (0: disable; 1: enable)
+                 */
+                break
             }
         case 0xC000 ... 0xDFFF:
-            if aAddress % 2 == 0
+            switch isEven
             {
-                self.writeIRQLatch(value: aValue)
-            }
-            else
-            {
-                self.writeIRQReload()
+            case true:
+                /*
+                 IRQ latch ($C000-$DFFE, even)
+                 7  bit  0
+                 ---- ----
+                 DDDD DDDD
+                 |||| ||||
+                 ++++-++++- IRQ latch value
+                 */
+                self.reload = aValue
+            case false:
+                /*
+                 IRQ reload ($C001-$DFFF, odd)
+                 7  bit  0
+                 ---- ----
+                 xxxx xxxx
+                 */
+                self.counter = 0
             }
         case 0xE000 ... 0xFFFF:
-            self.irqEnable = aAddress % 2 == 1
+            /*
+             IRQ disable ($E000-$FFFE, even)
+             IRQ enable ($E001-$FFFF, odd)
+             */
+            self.irqEnable = !isEven
         default: break
         }
-    }
-
-    private mutating func writeBankSelect(value aValue: UInt8)
-    {
-        self.prgMode = (aValue >> 6) & 1
-        self.chrMode = (aValue >> 7) & 1
-        self.register = aValue & 7
-        self.updateOffsets()
-    }
-
-    private mutating func writeBankData(value aValue: UInt8)
-    {
-        self.registers[Int(self.register)] = aValue
-        self.updateOffsets()
-    }
-
-    private mutating func writeMirror(value aValue: UInt8)
-    {
-        self.mirroringMode = aValue & 1 == 0 ? .vertical : .horizontal
-    }
-
-    private func writeProtect()
-    {
-        
-    }
-    
-    private mutating func writeIRQLatch(value aValue: UInt8)
-    {
-        self.reload = aValue
-    }
-
-    private mutating func writeIRQReload()
-    {
-        self.counter = 0
     }
 
     private func prgBankOffset(index aIndex: Int) -> Int
@@ -335,6 +387,9 @@ struct Mapper_MMC3: MapperProtocol
             self.prgOffsets[3] = self.prgBankOffset(index: -1)
         default: break
         }
+        
+        guard !self.isChrRamEnabled else { return } // prevent calling chrBankOffset with empty CHR ROM
+
         switch self.chrMode {
         case 0:
             self.chrOffsets[0] = self.chrBankOffset(index: Int(self.registers[0] & 0xFE))

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_MMC3.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_MMC3.swift
@@ -41,10 +41,10 @@ struct Mapper_MMC3: MapperProtocol
     private let chr: [UInt8]
     
     /// 8KB of CHR RAM used if there is no CHR ROM onboard (used only on TNROM variant boards - Famicom only)
-    private var chrRam: [UInt8] = [UInt8].init(repeating: 0, count: 8192)
+    private var chrRam: [UInt8]
     
     /// 8KB of SRAM addressible through 0x6000 ... 0x7FFF
-    private var sram: [UInt8] = [UInt8].init(repeating: 0, count: 8192)
+    private var sram: [UInt8]
     
     private var register: UInt8
     private var registers: [UInt8]
@@ -77,7 +77,7 @@ struct Mapper_MMC3: MapperProtocol
         self.isChrRamEnabled = chrRom.isEmpty
         
         if let safeState = aState,
-           safeState.uint8s.count >= 8205,
+           safeState.uint8s.count >= 16397,
            safeState.bools.count >= 1,
            safeState.ints.count >= 12
         {
@@ -92,6 +92,7 @@ struct Mapper_MMC3: MapperProtocol
             self.reload = safeState.uint8s[11]
             self.counter = safeState.uint8s[12]
             self.sram = [UInt8](safeState.uint8s[13 ..< 8205])
+            self.chrRam = [UInt8](safeState.uint8s[8205 ..< 16397])
         }
         else
         {
@@ -106,6 +107,7 @@ struct Mapper_MMC3: MapperProtocol
             self.reload = 0
             self.counter = 0
             self.sram = [UInt8].init(repeating: 0, count: 8192)
+            self.chrRam = [UInt8].init(repeating: 0, count: 8192)
             
             self.prgOffsets[0] = self.prgBankOffset(index: 0)
             self.prgOffsets[1] = self.prgBankOffset(index: 1)
@@ -120,6 +122,7 @@ struct Mapper_MMC3: MapperProtocol
         {
             var u8s: [UInt8] = [self.register, self.registers[0], self.registers[1], self.registers[2], self.registers[3], self.registers[4], self.registers[5], self.registers[6], self.registers[7], self.prgMode, self.chrMode, self.reload, self.counter]
             u8s.append(contentsOf: self.sram)
+            u8s.append(contentsOf: self.chrRam)
             return MapperState(
                 mirroringMode: self.mirroringMode.rawValue,
                 ints: [self.prgOffsets[0], self.prgOffsets[1], self.prgOffsets[2], self.prgOffsets[3], self.chrOffsets[0], self.chrOffsets[1], self.chrOffsets[2], self.chrOffsets[3], self.chrOffsets[4], self.chrOffsets[5], self.chrOffsets[6], self.chrOffsets[7]],
@@ -132,7 +135,7 @@ struct Mapper_MMC3: MapperProtocol
         {
             self.mirroringMode = MirroringMode.init(rawValue: newValue.mirroringMode) ?? self.mirroringMode
             
-            guard newValue.uint8s.count >= 8205,
+            guard newValue.uint8s.count >= 16397,
                   newValue.bools.count >= 1,
                   newValue.ints.count >= 12
             else
@@ -150,6 +153,7 @@ struct Mapper_MMC3: MapperProtocol
             self.reload = newValue.uint8s[11]
             self.counter = newValue.uint8s[12]
             self.sram = [UInt8](newValue.uint8s[13 ..< 8205])
+            self.chrRam = [UInt8](newValue.uint8s[8205 ..< 16397])
         }
     }
     

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_MMC3.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_MMC3.swift
@@ -32,7 +32,7 @@ struct Mapper_MMC3: MapperProtocol
     
     let hasExtendedNametableMapping: Bool = false
     
-    var mirroringMode: MirroringMode
+    private(set) var mirroringMode: MirroringMode
     
     /// linear 1D array of all PRG blocks
     private let prg: [UInt8]

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_MMC4.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_MMC4.swift
@@ -32,7 +32,7 @@ struct Mapper_MMC4: MapperProtocol
     
     let hasExtendedNametableMapping: Bool = false
     
-    var mirroringMode: MirroringMode
+    private(set) var mirroringMode: MirroringMode
     
     /// linear 1D array of all PRG blocks
     private let prg: [UInt8]

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_NTDEC2722.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_NTDEC2722.swift
@@ -32,7 +32,7 @@ struct Mapper_NTDEC2722: MapperProtocol
     
     let hasExtendedNametableMapping: Bool = false
     
-    var mirroringMode: MirroringMode
+    private(set) var mirroringMode: MirroringMode
     
     private var prgBank: Int
     private var cycles: Int

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_Namcot118_TengenMimic1.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_Namcot118_TengenMimic1.swift
@@ -32,7 +32,7 @@ struct Mapper_Namcot118_TengenMimic1: MapperProtocol
     
     let hasExtendedNametableMapping: Bool = false
     
-    var mirroringMode: MirroringMode
+    private(set) var mirroringMode: MirroringMode
     
     /// linear 1D array of all PRG blocks
     private var prg: [UInt8] = []

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_TQROM.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_TQROM.swift
@@ -34,7 +34,7 @@ struct Mapper_TQROM: MapperProtocol
     // MARK: - Internal Variables
     let hasStep: Bool = true
     let hasExtendedNametableMapping: Bool = false
-    var mirroringMode: MirroringMode
+    private(set) var mirroringMode: MirroringMode
     
     // MARK: - Private Variables
     /// linear 1D array of all PRG blocks

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_VRC2b_VRC4e_VRC4f.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_VRC2b_VRC4e_VRC4f.swift
@@ -35,7 +35,7 @@ struct Mapper_VRC2b_VRC4e_VRC4f: MapperProtocol
     
     let hasExtendedNametableMapping: Bool = false
     
-    var mirroringMode: MirroringMode
+    private(set) var mirroringMode: MirroringMode
     
     /// linear 1D array of all PRG blocks
     private var prg: [UInt8] = []

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_VRC2c_VRC4b_VRC4d.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_VRC2c_VRC4b_VRC4d.swift
@@ -35,7 +35,7 @@ struct Mapper_VRC2c_VRC4b_VRC4d: MapperProtocol
     
     let hasExtendedNametableMapping: Bool = false
     
-    var mirroringMode: MirroringMode
+    private(set) var mirroringMode: MirroringMode
     
     /// linear 1D array of all PRG blocks
     private var prg: [UInt8] = []

--- a/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_VRC7.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/Mappers/Mapper_VRC7.swift
@@ -35,7 +35,7 @@ struct Mapper_VRC7: MapperProtocol
     
     let hasExtendedNametableMapping: Bool = false
     
-    var mirroringMode: MirroringMode
+    private(set) var mirroringMode: MirroringMode
     
     /// linear 1D array of all PRG blocks
     private var prg: [UInt8] = []


### PR DESCRIPTION
**CPU:**
- instruction table updates - add timings for alternate SBC function and NOPs, and all illegal opcodes
- implement all illegal 6502 instructions

**Mapper 4 (MMC3)**:
- support the TNROM variant which is used in some Famicom Games (notably FFIII), which has 8KB CHR RAM instead of CHR ROM

**Mapper 5 (MMC5):**
- implement additional PRG and CHR banking modes
- smaller save states
- additional safety checks for save state loading

**Mapper 7 (AxROM):**
- fix an issue where a ROM could request a banking offset beyond what the cartridge offers
- save state format update

**Mapper 9 (MMC2):**
- fix an issue where a ROM could request a banking offset beyond what the cartridge offers

**Mapper 11 (ColorDreams):**
- fix an issue where a ROM could request a banking offset beyond what the cartridge offers

**Mapper 66 (GxROM):**
- fix an issue where a ROM could request a banking offset beyond what the cartridge offers
- fix banking issues due to this mapper originally being combined with ColorDreams mapper.  it is different enough that it Neds its own file.

**Mapper 78:**
- fix an issue where a ROM could request a banking offset beyond what the cartridge offers

This should fix compatibility with some games.  More test ROMs are passing.