### PR TITLE
APU Fixes into Dev Branch

### DIFF
--- a/nes-emu-ios/nes-emu-ios/Model/NES/CPU.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/NES/CPU.swift
@@ -409,7 +409,7 @@ struct CPU
         self.pc = self.read16(address: 0xFFFC)
         self.sp = 0xFD
         self.set(flags: 0x24)
-        
+        self.apu.writeRegister(address: 0x4015, value: 0)
         self.ppu.reset()
     }
     

--- a/nes-emu-ios/nes-emu-ios/Model/SaveState/Bridge/NSManagedObject+APUState.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/SaveState/Bridge/NSManagedObject+APUState.swift
@@ -46,10 +46,11 @@ extension NSManagedObject
             let framePeriod: UInt8 = (self.value(forKeyPath: "framePeriod") as? Data)?.to(type: UInt8.self) ?? 0
             let frameValue: UInt8 = (self.value(forKeyPath: "frameValue") as? Data)?.to(type: UInt8.self) ?? 0
             let frameIRQ: Bool = (self.value(forKeyPath: "frameIRQ") as? Bool) ?? false
+            let frameIRQInhibited: Bool = (self.value(forKeyPath: "frameIRQInhibited") as? Bool) ?? false
             let audioBuffer: [Float32] = (self.value(forKeyPath: "audioBuffer") as? Data)?.toArray(type: Float32.self) ?? []
             let audioBufferIndex: UInt32 = (self.value(forKeyPath: "audioBufferIndex") as? Data)?.to(type: UInt32.self) ?? 0
             
-            return APUState(cycle: cycle, framePeriod: framePeriod, frameValue: frameValue, frameIRQ: frameIRQ, audioBuffer: audioBuffer, audioBufferIndex: audioBufferIndex, pulse1: pulseStates[0], pulse2: pulseStates[1], triangle: triangleState, noise: noiseState, dmc: dmcState)
+            return APUState(cycle: cycle, framePeriod: framePeriod, frameValue: frameValue, frameIRQ: frameIRQ, frameIRQInhibited: frameIRQInhibited, audioBuffer: audioBuffer, audioBufferIndex: audioBufferIndex, pulse1: pulseStates[0], pulse2: pulseStates[1], triangle: triangleState, noise: noiseState, dmc: dmcState)
         }
         set
         {
@@ -61,6 +62,7 @@ extension NSManagedObject
             self.setValue(Data.init(from: safeNewValue.framePeriod), forKeyPath: "framePeriod")
             self.setValue(Data.init(from: safeNewValue.frameValue), forKeyPath: "frameValue")
             self.setValue(safeNewValue.frameIRQ, forKey: "frameIRQ")
+            self.setValue(safeNewValue.frameIRQInhibited, forKey: "frameIRQInhibited")
             self.setValue(Data.init(from: safeNewValue.audioBuffer), forKeyPath: "audioBuffer")
             self.setValue(Data.init(from: safeNewValue.audioBufferIndex), forKeyPath: "audioBufferIndex")
         }

--- a/nes-emu-ios/nes-emu-ios/Model/SaveState/CoreData/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
+++ b/nes-emu-ios/nes-emu-ios/Model/SaveState/CoreData/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17192" systemVersion="19H2" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22F82" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="APUState_CD" representedClassName="APUState_CD" syncable="YES" codeGenerationType="class">
         <attribute name="audioBuffer" optional="YES" attributeType="Binary"/>
         <attribute name="audioBufferIndex" optional="YES" attributeType="Binary"/>
         <attribute name="cycle" optional="YES" attributeType="Binary"/>
         <attribute name="frameIRQ" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="frameIRQInhibited" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="framePeriod" optional="YES" attributeType="Binary"/>
         <attribute name="frameValue" optional="YES" attributeType="Binary"/>
         <relationship name="consoleState" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ConsoleState_CD" inverseName="apuState" inverseEntity="ConsoleState_CD"/>
@@ -158,15 +159,4 @@
         <attribute name="timerValue" optional="YES" attributeType="Binary"/>
         <relationship name="apuState" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="APUState_CD" inverseName="triangleState" inverseEntity="APUState_CD"/>
     </entity>
-    <elements>
-        <element name="APUState_CD" positionX="-72" positionY="9" width="128" height="208"/>
-        <element name="ConsoleState_CD" positionX="-132.98828125" positionY="-183.0234375" width="128" height="148"/>
-        <element name="CPUState_CD" positionX="-193.65625" positionY="-18.19921875" width="128" height="208"/>
-        <element name="DMCState_CD" positionX="-81" positionY="0" width="128" height="238"/>
-        <element name="MapperState_CD" positionX="-81" positionY="117" width="128" height="133"/>
-        <element name="NoiseState_CD" positionX="-90" positionY="-9" width="128" height="268"/>
-        <element name="PPUState_CD" positionX="-21.28515625" positionY="-16.421875" width="128" height="733"/>
-        <element name="PulseState_CD" positionX="-108" positionY="-27" width="128" height="358"/>
-        <element name="TriangleState_CD" positionX="-99" positionY="-18" width="128" height="193"/>
-    </elements>
 </model>

--- a/nes-emu-ios/nes-emu-ios/Model/SaveState/Structs/APUState.swift
+++ b/nes-emu-ios/nes-emu-ios/Model/SaveState/Structs/APUState.swift
@@ -31,6 +31,7 @@ struct APUState
     let framePeriod: UInt8
     let frameValue: UInt8
     let frameIRQ: Bool
+    let frameIRQInhibited: Bool
     let audioBuffer: [Float32]
     let audioBufferIndex: UInt32
     let pulse1: PulseState


### PR DESCRIPTION
This PR aims to improve compatibility by fixing some issues with the Audio Processing Unit (APU):
- for APU channels, don't update length counter value if channel is disabled.  
- fix some issues with the way APU frameIRQ was set.  
- Clear DMC interrupt flag on write to 0x4015.  
- Update APU reset logic

changes are based on nesdev.org documentation